### PR TITLE
review: v3 reference file corrections by @migmcc

### DIFF
--- a/skills/measurement/msa-gauge-rr/references/gauge-rr-study-guide.md
+++ b/skills/measurement/msa-gauge-rr/references/gauge-rr-study-guide.md
@@ -7,7 +7,7 @@ version: "1.0"
 status: approved
 created: "2026-06-06"
 last_updated: "2026-06-06"
-updated_by: RBraga01
+updated_by: migmcc
 reviewed_by: RBraga01
 license: MIT
 ---
@@ -179,7 +179,7 @@ Both methods calculate EV, AV, and GRR. Choose based on the following:
 | 2 | 1.128 | 0.8862 | 3.267 |
 | 3 | 1.693 | 0.5908 | 2.574 |
 
-For appraiser variation (number of appraisers = 3), d₂* = 1.693 (use r = 3, m = 10 from d₂* table in AIAG MSA 4th ed. Appendix C).
+For appraiser variation (number of appraisers = 3), use K₂ = 0.5231 directly from AIAG MSA 4th ed. Table IV. This corresponds to d₂* ≈ 1.912 (range of 3 values, 1 range calculated). Note: the value 1.693 in the EV table above is d₂* for 3 trials per appraiser — it is not the correct value for the AV calculation.
 
 ### Step-by-Step Formulas
 

--- a/skills/measurement/spc-control-charts/references/chart-selection-guide.md
+++ b/skills/measurement/spc-control-charts/references/chart-selection-guide.md
@@ -7,7 +7,7 @@ version: "1.0"
 status: approved
 created: "2026-06-06"
 last_updated: "2026-06-06"
-updated_by: RBraga01
+updated_by: migmcc
 reviewed_by: RBraga01
 license: MIT
 ---
@@ -252,8 +252,8 @@ These include all variation sources (between-subgroup drift, shifts, etc.).
 
 | Cpk / Ppk | Sigma level (approx.) | DPPM (approx.) | PPAP / IATF verdict |
 |-----------|----------------------|----------------|---------------------|
-| ≥ 1.67 | 5σ | < 57 ppm | Excellent — accepted without restriction |
-| 1.33 – 1.67 | 4σ | 57 – 6,210 ppm | Acceptable — accepted, increased monitoring recommended for new processes |
+| ≥ 1.67 | 5σ | < 233 ppm | Excellent — accepted without restriction |
+| 1.33 – 1.67 | 4σ | 233 – 6,210 ppm | Acceptable — accepted, increased monitoring recommended for new processes |
 | 1.00 – 1.33 | 3σ | 6,210 – 66,807 ppm | Marginal — 100% inspection, corrective action, customer approval required |
 | < 1.00 | < 3σ | > 66,807 ppm | Not capable — PPAP blocked, mandatory corrective action |
 

--- a/skills/planning/apqp/references/phase-deliverables.md
+++ b/skills/planning/apqp/references/phase-deliverables.md
@@ -7,7 +7,7 @@ version: "1.0"
 status: approved
 created: "2026-06-06"
 last_updated: "2026-06-06"
-updated_by: RBraga01
+updated_by: migmcc
 reviewed_by: RBraga01
 license: MIT
 ---
@@ -215,6 +215,6 @@ Use alongside the [apqp](../SKILL.md) skill.
 | Master Sample retention | 4 | Element 15 — Master Sample |
 | Gauge Plan → gauges procured and calibrated | 3–4 | Element 16 — Checking Aids |
 | CSR Compliance / OEM-specific requirements | 1–4 | Element 17 — Customer-Specific Requirements |
-| Programme Charter + Management Sign-Off | 4 | Element 18 — Part Submission Warrant (PSW) |
+| Quality Planning Sign-Off + Management Support Sign-Off | 4 | Element 18 — Part Submission Warrant (PSW) |
 
 **Note:** Element 18 (PSW) is the culmination of the entire APQP programme — it can only be signed when all prior deliverables are complete and accepted. The PSW signature is the quality manager's attestation that the APQP process was followed.

--- a/skills/planning/dvp-test-plan/references/dvp-template.md
+++ b/skills/planning/dvp-test-plan/references/dvp-template.md
@@ -7,7 +7,7 @@ version: "1.0"
 status: approved
 created: "2026-06-06"
 last_updated: "2026-06-06"
-updated_by: RBraga01
+updated_by: migmcc
 reviewed_by: RBraga01
 license: MIT
 ---
@@ -336,9 +336,10 @@ Establishes that the product meets its reliability target (e.g., B10 life, desig
 | C — Regulatory / Safety | EMC, crash, homologation | Per regulation; typically 3 | Cannot deviate without regulatory authority; some regulations specify exact quantities |
 
 **Statistical guidance for reliability claims:**
-- B10 life at 90% confidence with Weibull shape parameter β = 2: minimum n = 5 (zero failures expected)
-- B10 life at 90% confidence with β = 1 (exponential): minimum n = 12 (zero failures expected)
-- Use the AMSAA / Crow reliability growth tool or Weibull analysis software to confirm adequacy before test execution
+- B10 life at 90% confidence with Weibull shape parameter β = 2: minimum n = 5 — but only if the test duration is extended to ≈ 2.1× the B10 design life. Testing exactly to the B10 life with n = 5 does not achieve 90% confidence.
+- B10 life at 90% confidence with β = 1 (exponential): minimum n = 12 — requires test duration ≈ 1.8× the B10 design life.
+- For testing exactly to the B10 design life (no time extension): n ≥ 22 is required regardless of β, to achieve 90% confidence of ≥ 90% reliability. Use the formula n = ln(1−C) / ln(R) where C = 0.90 and R = 0.90.
+- Use the AMSAA / Crow reliability growth tool or Weibull analysis software to calculate the exact test duration multiplier for your β and n combination before committing to a test plan.
 
 ---
 

--- a/skills/problem-solving/dmaic/references/statistical-tools.md
+++ b/skills/problem-solving/dmaic/references/statistical-tools.md
@@ -7,7 +7,7 @@ version: "1.0"
 status: approved
 created: "2026-06-06"
 last_updated: "2026-06-06"
-updated_by: RBraga01
+updated_by: migmcc
 reviewed_by: RBraga01
 license: MIT
 ---
@@ -180,7 +180,7 @@ Running a capability study on a poor measurement system produces false Cpk value
 | Analysis | Minitab path | Excel equivalent | Notes |
 |---|---|---|---|
 | Gauge R&R (crossed) | Stat > Quality Tools > Gauge Study > Gauge R&R Study (Crossed) | Not available natively — use ANOVA table manually | Excel cannot compute %GRR components reliably; use Minitab or R |
-| Process capability (normal) | Stat > Quality Tools > Capability Analysis > Normal | NORM.DIST function for PPM estimate; no built-in Cpk function | Excel: Cpk = MIN((USL-AVERAGE(data))/(3*STDEV(data)), (AVERAGE(data)-LSL)/(3*STDEV(data))) |
+| Process capability (normal) | Stat > Quality Tools > Capability Analysis > Normal | NORM.DIST function for PPM estimate; no built-in Cpk function | Excel: the formula MIN((USL-AVERAGE(data))/(3*STDEV(data)), (AVERAGE(data)-LSL)/(3*STDEV(data))) uses STDEV() — the overall standard deviation — and therefore computes **Ppk**, not Cpk. For true Cpk, σ̂ must be estimated from within-subgroup variation (R̄/d₂ or S̄/c₄); this requires manual calculation or Minitab. |
 | Control chart I-MR | Stat > Control Charts > Variables Charts for Individuals > I-MR | No built-in control chart; manual calculation of UCL/LCL possible | Excel: UCL = x̄ + 2.66 × MR̄; LCL = x̄ - 2.66 × MR̄ |
 | Control chart Xbar-R | Stat > Control Charts > Variables Charts for Subgroups > Xbar-R | Manual calculation; A2, D3, D4 constants from table | Minitab preferred for automatic rule detection |
 | Normal probability plot | Stat > Basic Statistics > Normality Test (Anderson-Darling) | Insert > Chart > Normal probability plot (limited) | Use Minitab; Excel normal plot requires manual quantile calculation |

--- a/skills/problem-solving/pdca-improvement/references/pdca-examples.md
+++ b/skills/problem-solving/pdca-improvement/references/pdca-examples.md
@@ -7,7 +7,7 @@ version: "1.0"
 status: approved
 created: "2026-06-06"
 last_updated: "2026-06-06"
-updated_by: RBraga01
+updated_by: migmcc
 reviewed_by: RBraga01
 license: MIT
 ---
@@ -140,7 +140,7 @@ Use alongside the [pdca-improvement](../SKILL.md) skill.
 - Run-in protocol implemented on machine 3 Week 3; first tool change conducted under new protocol observed by SQE
 - 100% inspection of first 25 parts after tool change started Week 3
 - SPC chart updated with tool change markers Week 4
-- Run-in parts from three tool changes: 20 parts + 20 parts + 18 parts scrapped (first 20 were Ra > 1.6 µm in all three cases — confirming the cause mechanism)
+- Run-in parts from three tool changes: 20 parts + 20 parts + 20 parts scrapped (first 20 were Ra > 1.6 µm in all three cases — confirming the cause mechanism)
 
 **Do gate — passed:** Protocol implemented; run-in confirmation data collected; scrap documented and accepted by SubCo as cost of validation.
 
@@ -152,9 +152,9 @@ Use alongside the [pdca-improvement](../SKILL.md) skill.
 |---|---|---|---|
 | Ra non-conformance rate — steady state | 3.2% | ≤ 0.3% | 0.0% (0/1,140 steady-state parts) |
 | Ra non-conformance — run-in parts (scrapped) | Part of 3.2% | Scrapped | 100% of run-in parts exceeded Ra limit — confirms mechanism |
-| Scrap increase | Not tracked separately | Quantified | +18 parts per tool change; tool life = ~400 parts → +4.5% scrap rate on machine 3 |
+| Scrap increase | Not tracked separately | Quantified | +20 parts per tool change (run-in protocol); tool life = ~400 parts → +5.0% scrap rate on machine 3 |
 
-**Check gate — passed with cost note:** PPM target met for steady-state production. Run-in scrap rate (+4.5%) is a trade-off and was accepted in the Plan — business case confirmed it is preferable to non-conformance at the customer. Financial impact to be reviewed quarterly.
+**Check gate — passed with cost note:** PPM target met for steady-state production. Run-in scrap rate (+5.0%) is a trade-off and was accepted in the Plan — business case confirmed it is preferable to non-conformance at the customer. Financial impact to be reviewed quarterly.
 
 ---
 


### PR DESCRIPTION
## Summary

Audit of 13 reference files assigned in [review-brief-migmcc-v3.md](docs/review-brief-migmcc-v3.md). 6 files required corrections; 7 were verified correct with no changes.

### Files corrected (6)

| File | Correction |
|------|-----------|
| `skills/problem-solving/pdca-improvement/references/pdca-examples.md` | Fixed scrap count inconsistency in DO/CHECK sections: 18 → 20 parts, 4.5% → 5.0% (consistent with 20-part run-in protocol) |
| `skills/problem-solving/dmaic/references/statistical-tools.md` | Clarified that the Excel `STDEV()` formula in the Cpk note computes **Ppk** (overall σ), not Cpk; added note on within-subgroup σ̂ requirement |
| `skills/planning/apqp/references/phase-deliverables.md` | Corrected PPAP Element 18 (PSW) cross-reference: "Programme Charter" (Phase 1 output) → "Quality Planning Sign-Off + Management Support Sign-Off" (Phase 4 outputs) |
| `skills/planning/dvp-test-plan/references/dvp-template.md` | Expanded reliability sample size guidance: added required test duration multipliers (2.1× for n=5/β=2, 1.8× for n=12/β=1) and added n≥22 rule for testing to exactly the B10 design life |
| `skills/measurement/msa-gauge-rr/references/gauge-rr-study-guide.md` | Corrected explanatory note for AV constant: d₂*=1.693 is for EV (3 trials) not AV (3 appraisers); correct value is K₂=0.5231 (d₂*≈1.912) per AIAG MSA 4th ed. Table IV |
| `skills/measurement/spc-control-charts/references/chart-selection-guide.md` | Corrected DPPM for Cpk≥1.67 row: 57 ppm → 233 ppm using the 1.5σ shift model consistent with the other rows (6,210 and 66,807 ppm) |

### Files verified correct — no changes (7)

- `skills/problem-solving/fishbone-analysis/references/6m-category-guide.md`
- `skills/problem-solving/is-is-not-scoping/references/hypothesis-elimination.md`
- `skills/planning/ppap/references/18-elements-checklist.md`
- `skills/planning/control-plan/references/control-plan-template.md`
- `skills/audit/vda-6-3-audit/references/p1-p7-questions.md`
- `skills/supplier-quality/supplier-scar/references/scar-template.md`
- `skills/documentation/car-corrective-action/references/car-template.md`

## Test plan

- [ ] Verify DPPM values in chart-selection-guide.md match 1.5σ shift model (6σ: 3.4 ppm; 5σ: 233 ppm; 4σ: 6,210 ppm; 3σ: 66,807 ppm)
- [ ] Verify Gauge R&R AV constant: K₂=0.5231 = 1/d₂* where d₂*≈1.912 (AIAG MSA 4th ed. Table IV, r=3, m=1)
- [ ] Verify DVP reliability formula: n = ln(1−0.90)/ln(0.90) = 21.85 → 22 for testing to exactly B10 life
- [ ] Verify APQP Section 8 cross-reference: PSW traces to Phase 4 "Quality Planning Sign-Off" and "Management Support Sign-Off"
- [ ] Verify pdca-examples.md: DO section shows 20 parts scrapped in all three cycles; CHECK table shows +5.0% scrap rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)