### PR TITLE
chore: separate original content from third-party standards, add notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,3 +240,26 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the skill format and submission proce
 **[@RBraga01](https://github.com/RBraga01)** — 15+ years in quality engineering. Claim manager for ~30 electronic component suppliers — receives OEM customer complaints and manages the full escalation to the respective suppliers. Created Quality Engineering Skills to bring structured methodology to AI agents in the quality domain.
 
 **[@migmcc](https://github.com/migmcc)** — 25+ years in quality engineering. Claim manager handling OEM customer complaints and escalations across electromechanical and mechanical suppliers. 8D and problem-solving expert. Responsible for the skill content that makes the methodology accurate and practitioner-grade.
+
+---
+
+## Standards and trademarks
+
+These skills describe how quality methodologies work and cite the clause or step
+each one corresponds to. They **do not reproduce** the standards themselves —
+no rating criteria tables, question catalogues, forms or worksheets are copied
+from any manual. Where a value is defined only by the authoritative document, the
+skill tells the agent to consult your licensed copy rather than guess.
+
+The MIT licence covers this repository's original content only. It does not
+extend to any ISO, IATF, AIAG or VDA publication, and owning the rights to use a
+standard remains your responsibility.
+
+ISO, IATF, AIAG, VDA and the OEM names used here are trademarks of their
+respective owners. **This project is not affiliated with, endorsed by, or
+certified by any of them.** Using these skills does not make anything compliant
+with a standard and does not substitute for audit or certification by an
+accredited body.
+
+See [THIRD_PARTY_CONTENT.md](THIRD_PARTY_CONTENT.md) for the per-standard
+breakdown of what this project contains and on what basis.

--- a/THIRD_PARTY_CONTENT.md
+++ b/THIRD_PARTY_CONTENT.md
@@ -1,0 +1,75 @@
+# Third-Party Content
+
+Quality-Engineering-Skills teaches methodologies defined in standards published by
+ISO, IATF, AIAG and VDA. Those standards are **separately licensed works owned by
+their publishers**. This project does not include them, does not reproduce them,
+and cannot grant anyone rights to them.
+
+This file records, for every skill that rests on a third-party standard, what the
+project actually contains and on what basis.
+
+## The rule this project follows
+
+**Methods are described. Documents are not reproduced.**
+
+Copyright protects the particular expression a publisher wrote — its tables as
+compiled and laid out, its prose, its examples, its rating criteria. It does not
+protect the underlying method, procedure or system. This project therefore:
+
+- describes how a method works, in its own words and its own structure
+- states which clause or step of which standard a method corresponds to, so a
+  practitioner can find the authoritative text
+- **does not** copy rating criteria tables, question banks, checklists, forms or
+  worksheets out of a manual
+- **does not** position itself as a substitute for owning the manual
+
+Where a skill needs a value that only the authoritative document defines, the
+skill instructs the agent to consult the user's licensed copy rather than guess.
+
+## Trademarks
+
+ISO, IATF, AIAG, VDA, and the OEM names appearing in these skills (Ford, BMW,
+Volkswagen, Stellantis, General Motors and others) are trademarks of their
+respective owners. They are used here descriptively, to identify which standard
+or customer requirement a skill addresses.
+
+**This project is not affiliated with, endorsed by, certified by, or accredited
+by any of these organisations.** Using these skills does not make an
+organisation, a document or a process compliant with any standard, and does not
+substitute for certification or audit by an accredited body.
+
+## Scope of the MIT licence
+
+The MIT licence in [LICENSE](LICENSE) covers **the original content of this
+repository** — the skill instructions, structure, decision logic as expressed
+here, agent definitions, templates authored for this project, and tooling.
+
+It does **not** and cannot extend to any third-party standard referenced below.
+Obtaining the rights to use a standard is the user's responsibility.
+
+## Content basis by standard
+
+| Standard | Publisher | What this project contains | Basis |
+|---|---|---|---|
+| ISO 9001 | ISO | Clause-referenced audit guidance and internally authored question prompts | Method described; clause numbers cited for lookup. No text from the standard. |
+| IATF 16949 | IATF | Supplemental requirement guidance, CSR and contingency-planning prompts | Method described; clause numbers cited. No text from the standard. |
+| AIAG-VDA FMEA Handbook (2019) | AIAG / VDA | 7-step process guidance; Action Priority decision logic restated as banded rules in `skills/risk-analysis/pfmea-process/assets/ap-table.md` | Independent restatement of the AP method. The handbook's enumerated AP table and its S/O/D rating criteria are **not** included — skills direct the user to their licensed copy for those. |
+| AIAG APQP / Control Plan | AIAG | Phase and gate structure, deliverable checklists authored for this project | Method described. No manual text, forms or worksheets. |
+| AIAG PPAP | AIAG | Level and element structure, submission guidance | Method described. No forms. |
+| AIAG / AIAG-VDA SPC | AIAG / VDA | Chart selection logic, Western Electric rules, capability index formulas | Formulas and control-chart rules are mathematics and long-standing published practice, not the publisher's expression. |
+| AIAG MSA | AIAG | Study types, %GRR and ndc interpretation guidance | Method described; acceptance thresholds are widely published industry practice. |
+| VDA 6.3 | VDA | Process audit element structure P1–P7 and rating scale description | Structure described. The VDA question catalogue is **not** included. |
+| VDA Volume 4 / 8D | VDA | D0–D8 discipline structure and evidence gates authored for this project | Method described. No VDA forms or templates. |
+| GB/T 29076—2021 | SAC (China) | Zeroing workflow structure and evidence gates | Method described; clause traceability cited. No standard text. |
+
+## Reporting a concern
+
+If you are a rights holder and believe something in this repository exceeds the
+basis described above, open a GitHub Issue labelled `security` or contact the
+maintainer, and it will be reviewed and removed or rewritten promptly. We would
+rather rewrite something than argue about it.
+
+## Note
+
+This document records the project's approach to third-party material. It is not
+legal advice and has not been reviewed by counsel.

--- a/skills/risk-analysis/action-priority-ap/SKILL.md
+++ b/skills/risk-analysis/action-priority-ap/SKILL.md
@@ -37,7 +37,8 @@ Assign and audit Action Priority (AP) ratings correctly using the AIAG-VDA 2019 
 ☐ Confirm O is based on the Failure Cause with current prevention controls in place
 ☐ Confirm D is based on current detection controls for this Failure Mode
 ☐ All S, O, and D ratings are supported by data, field history, capability data, or documented engineering judgement — not guesses
-☐ Assign AP using the full AIAG-VDA AP table (see [ap-table.md](../pfmea-process/assets/ap-table.md)) — not only the summary patterns in this skill
+☐ Assign AP using the full AP determination rules (see [ap-table.md](../pfmea-process/assets/ap-table.md)) — not only the summary patterns in this skill
+☐ For formal PPAP submissions, customer-facing FMEAs, or any disputed rating, confirm against your licensed AIAG-VDA FMEA Handbook — the rating criteria that make an S, O or D value defensible are in the handbook, not in this skill
 ☐ For every H-AP item: define a corrective action with owner and target date, or document a formal escalation rationale
 ☐ Reassess AP only after the corrective action is implemented and verified — not when only planned
 ☐ Verify Special Characteristics are rated S = 9 or 10
@@ -101,7 +102,7 @@ M-AP does not mean "no action needed." It means action is not mandatory, but the
 
 ## AP Assessment Workflow
 
-> This skill explains AP logic and decision patterns. Use the full AP table ([ap-table.md](../pfmea-process/assets/ap-table.md)) for final rating assignment. Do not rely solely on the summary patterns below for disputed cases or formal PPAP submissions.
+> This skill explains AP logic and decision patterns. Use the full AP determination rules ([ap-table.md](../pfmea-process/assets/ap-table.md)) for final rating assignment. Do not rely solely on the summary patterns below for disputed cases or formal PPAP submissions — those require the rating criteria in your licensed AIAG-VDA FMEA Handbook.
 
 **Before assigning AP:** Do not assign AP unless S, O, and D are already justified based on the linked failure effect, failure cause, and current controls. AP is only as good as the ratings it is built on.
 

--- a/skills/risk-analysis/pfmea-process/assets/ap-table.md
+++ b/skills/risk-analysis/pfmea-process/assets/ap-table.md
@@ -10,17 +10,33 @@ last_updated: "2026-06-03"
 updated_by: RBraga01
 reviewed_by: RBraga01
 license: MIT
+license-note: >-
+  MIT covers the original expression in this file. It does not extend to the
+  AIAG-VDA FMEA Handbook, which is a separately licensed third-party work.
+  See THIRD_PARTY_CONTENT.md.
 ---
 
-# AIAG-VDA Action Priority (AP) Table
+# Action Priority (AP) Determination Rules
 
-Reference: AIAG-VDA FMEA Handbook 2019, Step 5, Table 5-3
+**What this file is.** An independent restatement of the Action Priority decision
+logic used in the AIAG-VDA FMEA methodology (2019 joint edition), expressed as
+banded rules. It is **not** a reproduction of the handbook's Action Priority
+table, and it does not replace it.
 
-## How to read the table
+**What this file is not.** The authoritative AP table enumerates every S/O/D
+combination and comes with the rating criteria tables that define what each S, O
+and D value means. Those criteria are what make a rating defensible in an audit,
+and they are not in this file. For formal PPAP submissions, customer-facing FMEA
+work, or any disputed rating, use your own licensed copy of the handbook.
+
+AIAG and VDA are trademarks of their respective owners. This project is not
+affiliated with, endorsed by, or certified by either organisation.
+
+## How to apply the rules
 
 1. Find the Severity (S) row
-2. Find the Occurrence (O) column range
-3. Find the Detection (D) range
+2. Find the Occurrence (O) band
+3. Find the Detection (D) band
 4. Read the Action Priority: **H** (High), **M** (Medium), **L** (Low)
 
 ## Absolute rules (override the table)
@@ -30,7 +46,7 @@ Reference: AIAG-VDA FMEA Handbook 2019, Step 5, Table 5-3
 | S = 9 or 10 | Always **H** — regardless of O and D |
 | S = 8, O = 4–10 | **H** if D ≥ 5; **M** if D ≤ 4 |
 
-## AP Table (AIAG-VDA 2019 summary)
+## AP decision rules (banded)
 
 | S | O | D | AP |
 |---|---|---|----|


### PR DESCRIPTION
## Why

The external review flagged that `ap-table.md` identified itself as the AIAG-VDA
Action Priority table from "Handbook 2019, Step 5, Table 5-3" while carrying
`license: MIT`. MIT cannot grant rights over a third-party manual, and the
framing implied the file *was* the handbook's table rather than our restatement
of the method.

Note this is narrower than it first looked. The file never contained the real
Table 5-3 — that table enumerates all 1000 S/O/D combinations. What we have is
20 banded rules, which is already our own expression of the method. The problem
was the labelling and the licence stamp, not the substance.

## What changed

Wording and scope only:

- retitled to **Action Priority (AP) Determination Rules**, reframed as an
  independent restatement of the method, explicitly not a reproduction
- states what the file does **not** contain — the enumerated table and the S/O/D
  rating criteria — and sends the user to their licensed handbook for formal
  PPAP, customer-facing FMEA, and disputed ratings
- `license: MIT` kept for the original expression, bounded by a scope note
- `action-priority-ap` no longer calls the asset "the full AIAG-VDA AP table"
- new `THIRD_PARTY_CONTENT.md`: per-standard record of what the project contains
  and on what basis (methods described, clauses cited, never manual text, rating
  criteria, question catalogues or forms)
- README gains a standards-and-trademarks section with non-affiliation and
  non-compliance disclaimers

`LICENSE` is deliberately untouched so GitHub keeps detecting MIT and the badge
and `npx skills add` path keep working.

## Quality impact: none

**Zero AP rule rows were modified.** Every classification the skill produces is
byte-identical. Verified with `git diff` filtered to rule rows — no output.

Arguably the guidance improved: the skill now tells the agent when it genuinely
needs the licensed handbook instead of implying this repo is authoritative.

## Validation

- `python scripts/validate_skills.py` — passed, 31 SKILL.md / 59 .md files

## Review note

@migmcc — flagging this one for you specifically because it is about how we
position the AIAG-VDA material, not about methodology. If any wording reads as
weakening the practitioner value, say so and we will re-word.

This is not legal advice and has not been reviewed by counsel. It reduces
exposure and makes the project's position explicit; a proper IP review is still
worth doing before monetisation.
