### PR TITLE
fix: welcome workflow has never run — invalid YAML

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -36,20 +36,43 @@ jobs:
             const previousCount = issues.length - 1;
             if (previousCount > 0) return;
 
+            // Built as an array and joined so every line stays indented inside the
+            // YAML block scalar. A bare multi-line template literal starting at
+            // column 0 terminates the scalar and makes this whole file invalid YAML.
+            const issueBody = [
+              `Thanks for opening your first issue on **Quality-Engineering-Skills**, @${actor}! 👋`,
+              ``,
+              `A few things that help us respond faster:`,
+              ``,
+              `- **Methodology error** (wrong clause, wrong rating table, incorrect formula): include the standard edition you're referencing and what the file says vs. what it should say`,
+              `- **Skill submission**: check [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) — your skill must score ≥9/10 with \`/skill-auditor\` before opening a PR`,
+              `- **Question**: include your industry context (automotive, electronics, aerospace, medical) — it helps us give a more targeted answer`,
+              ``,
+              `We'll get back to you within 48 hours.`,
+            ].join('\n');
+
+            const prBody = [
+              `Thanks for your first contribution to **Quality-Engineering-Skills**, @${actor}! 🎉`,
+              ``,
+              `Before we review, please confirm:`,
+              ``,
+              `- [ ] \`name\` in frontmatter matches the directory name exactly`,
+              `- [ ] Description trigger phrases appear within the first 400 characters`,
+              `- [ ] \`## Output Format\` section is present with the standard A/B/C ask`,
+              `- [ ] All referenced files in \`## Reference files\` exist on disk`,
+              `- [ ] Tested with \`/skill-auditor\` — score ≥ 9/10 required`,
+              ``,
+              `See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for the full checklist.`,
+              ``,
+              `@RBraga01 will review within 48 hours.`,
+            ].join('\n');
+
             if (isIssue) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo:  context.repo.repo,
                 issue_number: context.issue.number,
-                body: `Thanks for opening your first issue on **Quality-Engineering-Skills**, @${actor}! 👋
-
-A few things that help us respond faster:
-
-- **Methodology error** (wrong clause, wrong rating table, incorrect formula): include the standard edition you're referencing and what the file says vs. what it should say
-- **Skill submission**: check [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) — your skill must score ≥9/10 with \`/skill-auditor\` before opening a PR
-- **Question**: include your industry context (automotive, electronics, aerospace, medical) — it helps us give a more targeted answer
-
-We'll get back to you within 48 hours.`,
+                body: issueBody,
               });
             }
 
@@ -58,18 +81,6 @@ We'll get back to you within 48 hours.`,
                 owner: context.repo.owner,
                 repo:  context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                body: `Thanks for your first contribution to **Quality-Engineering-Skills**, @${actor}! 🎉
-
-Before we review, please confirm:
-
-- [ ] \`name\` in frontmatter matches the directory name exactly
-- [ ] Description trigger phrases appear within the first 400 characters
-- [ ] \`## Output Format\` section is present with the standard A/B/C ask
-- [ ] All referenced files in \`## Reference files\` exist on disk
-- [ ] Tested with \`/skill-auditor\` — score ≥ 9/10 required
-
-See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for the full checklist.
-
-@RBraga01 will review within 48 hours.`,
+                body: prBody,
               });
             }


### PR DESCRIPTION
## The finding

The Welcome workflow has **failed on every run since it was added**. All 20 runs in the retained history are failures, and each has **no jobs attached** — GitHub could not parse the file, so it never scheduled anything.

```
$ gh run list --workflow welcome.yml --limit 20 --json conclusion \
    --jq '[.[].conclusion] | group_by(.) | map({v:.[0], n:length})'
[{"n":20,"v":"failure"}]
```

This also explains a symptom that was visible in the repo: **issue #7 was opened by a first-time contributor on 2026-07-26 and received no welcome comment.** No first-time contributor has ever been greeted.

## Cause

The JS template literals holding the comment bodies started at **column 0**. A YAML block scalar ends at the first line indented less than the block, so the `script: |` scalar terminated mid-string and the remaining lines were parsed as top-level YAML. Line 48 then began with `- **Methodology`, and YAML reads `*` as an alias indicator:

```
yaml.scanner.ScannerError: while scanning an alias
  in .github/workflows/welcome.yml, line 48, column 3
expected alphabetic or numeric character, but found '*'
```

Worth noting `667720b` was titled "fix welcome.yml JS bug" — it fixed something, but not this, and the workflow has been silently dead the whole time. Nothing surfaces it because a parse failure produces a red run with no logs to read.

## The fix, and why not the obvious one

The obvious fix is to indent the literals until YAML is happy. That does not work: the block scalar indentation is 12 spaces, so it would land **inside the posted comment**, and 4+ leading spaces in Markdown render as a code block. The bullet list would ship as preformatted text.

Instead the bodies are built from arrays joined with `\n`. Every line stays properly indented inside the scalar, and the rendered output has no leading whitespace. I left a comment in the file explaining this, because the natural "cleanup" is to collapse it back into a template literal and that reintroduces the bug.

## Verification

- `welcome.yml` parses — triggers resolve to `issues`, `pull_request_target`
- All **six** workflow files parse (checked the rest while I was here; the other five were already fine)
- Extracted script passes `node --check`
- Rendered comment body has **zero** leading-space lines

The workflow triggers only on `issues`/`pull_request_target` opened, so this PR will not itself produce a run — the real proof is the next issue or first-time PR. Worth watching one land before considering it closed.

## Not fixed here

Issue #7 still needs an actual human answer about content provenance. The welcome bot would not have covered that anyway.
