### PR TITLE
chore: register quality-problem-zeroing, generate platform bundles from skills/

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -23,3 +23,9 @@ jobs:
 
       - name: Validate SKILL.md files and internal links
         run: python scripts/validate_skills.py
+
+      # skills/ is the source of truth; platforms/*/knowledge/ are generated copies.
+      # This fails when a SKILL.md change lands without regenerating the bundles,
+      # which is how they drifted to a pre-review v1.0 snapshot.
+      - name: Check platform knowledge bundles are in sync
+        run: python scripts/sync_platform_knowledge.py --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,55 @@ All notable changes to Quality-Engineering-Skills are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+**1 new skill** (PR #6, commits 190b202 / cbb4ffd, merged 2026-07-07):
+
+| Skill | Domain | Standard |
+|-------|--------|----------|
+| [quality-problem-zeroing](skills/problem-solving/quality-problem-zeroing/) | problem-solving | GB/T 29076—2021 |
+
+Contributed by [@Crow12138](https://github.com/Crow12138) — 双归零 (double-five zeroing) for
+aerospace and complex equipment: technical zeroing (定位准确、机理清楚、问题复现、措施有效、举一反三),
+management zeroing (过程清楚、责任明确、措施落实、严肃处理、完善规章), evidence gates, review and
+formal closure. First skill in the repository covering a Chinese national standard.
+
+Reference files added:
+
+| File | Purpose |
+|------|---------|
+| `quality-problem-zeroing/references/gbt-29076-2021-method-guide.md` | Method guide with clause traceability |
+| `quality-problem-zeroing/references/engineering-methods.md` | Supporting engineering analysis methods |
+| `quality-problem-zeroing/assets/zeroing-report-template.md` | Technical and management zeroing report template |
+
+### Changed
+
+- **Skill and agent counts corrected across all index files.** The skill above merged on
+  2026-07-07 but was never registered, so `README.md` (badge, header, coverage table, skill
+  index, roadmap), `STATUS.md` and `docs/index.html` continued to advertise 22 skills against
+  23 on disk for three weeks. All now read 23.
+- **`STATUS.md` file-count metric split.** The single "Reference files created: 23" row matched
+  neither `references/*.md` (22 at the time) nor references plus assets (25). Replaced with two
+  reproducible rows counting `references/` and `assets/` separately.
+- **Platform knowledge bundles regenerated from `skills/`** — 60 files across
+  `platforms/chatgpt/knowledge/` and `platforms/claude-ai/knowledge/`. Both bundles were v1.0
+  snapshots predating the v1.1 review round, so the ChatGPT GPT and the Claude.ai Project had
+  been serving pre-review content, including errors the review had already corrected.
+- **`docs/maintenance-checklist.md` §5 rewritten** — the manual `Copy-Item` per file instruction
+  is replaced by the generator. A manual step repeated 30+ times per release is a step that
+  gets skipped, and it was.
+
+### Tooling
+
+| File | Purpose |
+|------|---------|
+| `scripts/sync_platform_knowledge.py` | Generates the platform bundles from `skills/`. `--check` reports drift and exits non-zero; `--write` regenerates. Reports orphans rather than deleting them. |
+| `.github/workflows/quality-check.yml` | New step runs `--check` on every push and PR, so a SKILL.md change that skips the bundles fails the build. |
+
+---
+
 ## [v2.1.0] — 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 # Quality-Engineering-Skills
 
-**22 structured quality engineering skills and 8 agents for AI — ISO 9001, IATF 16949, AIAG-VDA FMEA, VDA 6.3, PPAP, APQP, SPC, MSA.**
+**23 structured quality engineering skills and 8 agents for AI — ISO 9001, IATF 16949, AIAG-VDA FMEA, VDA 6.3, PPAP, APQP, SPC, MSA.**
 Works with Claude Code, Codex CLI, Cursor, Gemini CLI, and any agentskills.io-compatible AI tool.
 
 **[→ rbraga01.github.io/Quality-Engineering-Skills](https://rbraga01.github.io/Quality-Engineering-Skills/)**
 
-[![Skills](https://img.shields.io/badge/skills-22-orange)](skills/)
+[![Skills](https://img.shields.io/badge/skills-23-orange)](skills/)
 [![Agents](https://img.shields.io/badge/agents-8-purple)](skills/agents/)
 [![agentskills.io](https://img.shields.io/badge/format-agentskills.io-0ea5e9)](https://agentskills.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -46,7 +46,7 @@ Every skill maps to specific standard clauses. Every agent validates methodology
 
 | Domain | Skills | Standards |
 |--------|--------|-----------|
-| Problem Solving | 8D (D0–D8), 5-Why, Fishbone, Is/Is-Not, PDCA, DMAIC | ISO 9001 §10.2, IATF 16949 §10.2.3 |
+| Problem Solving | 8D (D0–D8), 5-Why, Fishbone, Is/Is-Not, PDCA, DMAIC, Zeroing (双归零) | ISO 9001 §10.2, IATF 16949 §10.2.3, GB/T 29076—2021 |
 | Risk Analysis | PFMEA, DFMEA, Action Priority (AP) | AIAG-VDA FMEA 2019, IATF 16949 §8.3 |
 | Planning | PPAP (5 levels, 18 elements), APQP (5 phases), Control Plan, DVP&R | AIAG PPAP 4th Ed, IATF 16949 §8.3.4 |
 | Measurement | MSA / Gauge R&R, SPC / Control Charts | AIAG MSA 4th Ed, AIAG SPC 2nd Ed |
@@ -100,7 +100,7 @@ Automated audit and scoring of SKILL.md and REFERENCE files against framework st
 ## Skill index
 
 <details>
-<summary><strong>Problem Solving</strong> (ISO 9001 §10.2)</summary>
+<summary><strong>Problem Solving</strong> (ISO 9001 §10.2 · GB/T 29076—2021)</summary>
 
 | Skill | Description |
 |-------|-------------|
@@ -110,6 +110,7 @@ Automated audit and scoring of SKILL.md and REFERENCE files against framework st
 | [is-is-not-scoping](skills/problem-solving/is-is-not-scoping/) | Ford D2 problem scoping tool — defines problem boundary and eliminates hypotheses |
 | [pdca-improvement](skills/problem-solving/pdca-improvement/) | Plan-Do-Check-Act cycle structure with gate criteria for continuous improvement |
 | [dmaic](skills/problem-solving/dmaic/) | Six Sigma DMAIC — five-phase structured improvement for chronic, data-driven problems |
+| [quality-problem-zeroing](skills/problem-solving/quality-problem-zeroing/) | 双归零 double-five zeroing under GB/T 29076—2021 — technical and management zeroing with evidence gates and formal closure |
 
 </details>
 
@@ -211,7 +212,7 @@ metadata:
 
 ## Roadmap
 
-**v2 (current):** Problem solving · Risk analysis · PPAP · APQP · Control Plan · DVP&R · MSA · SPC · VDA 6.3 · DMAIC · Supplier SCAR — 22 skills, 8 agents
+**v2 (current):** Problem solving · Risk analysis · PPAP · APQP · Control Plan · DVP&R · MSA · SPC · VDA 6.3 · DMAIC · Supplier SCAR · Quality problem zeroing — 23 skills, 8 agents
 
 **v3:** AS9100 Rev D (aerospace) · ISO 13485 (medical devices) · HACCP / ISO 22000 (food safety)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,16 +1,22 @@
 # STATUS — Quality-Engineering-Skills
 
-_Last updated: 2026-06-06. Auto-updated each release._
+_Last updated: 2026-07-27. Auto-updated each release._
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Total skills | 22 |
+| Total skills | 23 |
 | Total agents | 8 |
-| Reference files created | 23 |
-| Skills with reference files | 22 / 22 |
-| Output Format section | 30 / 30 |
+| Files under `references/` | 24 |
+| Files under `assets/` | 4 |
+| Skills with reference files | 23 / 23 |
+| Output Format section | 31 / 31 |
+
+> **Counting convention.** The two file rows count `references/*.md` and `assets/*.md`
+> across `skills/` including `skills/agents/`. The previous single "Reference files
+> created: 23" row did not match either count on its own and has been split so the
+> numbers are reproducible.
 
 **Flag legend:** 🟢 complete (output format + primary reference file present) | 🟡 partial (output format present, reference files pending) | 🔴 stub
 
@@ -28,6 +34,7 @@ _Last updated: 2026-06-06. Auto-updated each release._
 | [is-is-not-scoping](skills/problem-solving/is-is-not-scoping/SKILL.md) | problem-solving | — | [hypothesis-elimination.md](skills/problem-solving/is-is-not-scoping/references/hypothesis-elimination.md) | ✅ | 🟢 |
 | [pdca-improvement](skills/problem-solving/pdca-improvement/SKILL.md) | problem-solving | — | [pdca-examples.md](skills/problem-solving/pdca-improvement/references/pdca-examples.md) | ✅ | 🟢 |
 | [dmaic](skills/problem-solving/dmaic/SKILL.md) | problem-solving | — | [statistical-tools.md](skills/problem-solving/dmaic/references/statistical-tools.md) | ✅ | 🟢 |
+| [quality-problem-zeroing](skills/problem-solving/quality-problem-zeroing/SKILL.md) | problem-solving | — | [gbt-29076-2021-method-guide.md](skills/problem-solving/quality-problem-zeroing/references/gbt-29076-2021-method-guide.md) | ✅ | 🟢 |
 
 ### Risk Analysis
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="color-scheme" content="dark light">
 <title>Quality Engineering Skills — AI Methodologies for ISO 9001, IATF 16949 & AIAG-VDA</title>
-<meta name="description" content="22 structured quality engineering skills and 8 agents for AI — 8D, PFMEA, PPAP, APQP, SPC, MSA, VDA 6.3 for automotive, electronics, aerospace and medical industries. Free and open source.">
+<meta name="description" content="23 structured quality engineering skills and 8 agents for AI — 8D, PFMEA, PPAP, APQP, SPC, MSA, VDA 6.3 for automotive, electronics, aerospace and medical industries. Free and open source.">
 <style>
 /* ── RESET & TOKENS ── */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -700,7 +700,7 @@ footer p { font-size:.78rem; color:var(--muted); }
       Free · Open Source · MIT License · v2.0
     </div>
     <h1>Quality engineering skills<br>for <span class="grad">AI agents</span></h1>
-    <p class="hero-sub">22 structured methodologies across 7 domains — 8D, PFMEA, PPAP, APQP, SPC, MSA, VDA 6.3. Grounded in ISO 9001, IATF 16949, and AIAG-VDA 2019. Works with ChatGPT, Claude, Gemini, Slack, Teams, and any agentskills.io-compatible tool.</p>
+    <p class="hero-sub">23 structured methodologies across 7 domains — 8D, PFMEA, PPAP, APQP, SPC, MSA, VDA 6.3. Grounded in ISO 9001, IATF 16949, and AIAG-VDA 2019. Works with ChatGPT, Claude, Gemini, Slack, Teams, and any agentskills.io-compatible tool.</p>
     <div class="hero-ctas">
       <a class="btn-primary" href="https://chatgpt.com/g/g-6a22e9e03f8881918c35741d618bad54-quality-engineering-assistant" target="_blank" rel="noopener">
         Try the GPT — Free →
@@ -815,7 +815,7 @@ footer p { font-size:.78rem; color:var(--muted); }
 <!-- ══════════ SKILL DOMAINS ══════════ -->
 <section class="section reveal" id="methodologies">
   <div class="section-tag">The Skills</div>
-  <h2>22 skills across 7 domains</h2>
+  <h2>23 skills across 7 domains</h2>
   <p class="section-sub">Every skill is grounded in a specific standard edition. No generic advice — structured workflows with validation gates, templates, and worked examples.</p>
   <div class="domain-grid">
 
@@ -825,7 +825,7 @@ footer p { font-size:.78rem; color:var(--muted); }
         <div class="domain-icon">🔧</div>
         <div>
           <h3>Problem Solving</h3>
-          <div class="std-ref">ISO 9001:2015 §10.2 · IATF 16949:2016 §10.2.3</div>
+          <div class="std-ref">ISO 9001:2015 §10.2 · IATF 16949:2016 §10.2.3 · GB/T 29076—2021</div>
         </div>
       </div>
       <ul class="skill-list skill-list-2col">
@@ -835,6 +835,7 @@ footer p { font-size:.78rem; color:var(--muted); }
         <li>Is / Is-Not Scoping — Ford D2 tool, hypothesis elimination<span class="skill-std">ISO 9001 §10.2</span></li>
         <li>PDCA Improvement Cycle — Plan-Do-Check-Act, gate criteria<span class="skill-std">ISO 9001 §10.3</span></li>
         <li>DMAIC — Six Sigma structured improvement, 5-phase method<span class="skill-std">ISO 9001 §10.3</span></li>
+        <li>Quality Problem Zeroing — 双归零 technical and management zeroing<span class="skill-std">GB/T 29076—2021</span></li>
       </ul>
     </div>
 
@@ -1156,7 +1157,7 @@ footer p { font-size:.78rem; color:var(--muted); }
     <div class="qs-card reveal">
       <div class="qs-num">3</div>
       <h3>Install via Claude Code / CLI</h3>
-      <p>One command installs all 22 skills and 8 agents directly into any AI coding environment. MIT licensed, fork-ready.</p>
+      <p>One command installs all 23 skills and 8 agents directly into any AI coding environment. MIT licensed, fork-ready.</p>
       <div class="code-block">
         <button class="copy-btn" onclick="copyCode(this)">Copy</button>
         <pre><code>npx skills add RBraga01/Quality-Engineering-Skills</code></pre>
@@ -1370,7 +1371,7 @@ footer p { font-size:.78rem; color:var(--muted); }
     <div class="licon">QE</div>
     <span>Quality Engineering Skills v2.0</span>
   </div>
-  <p>MIT License · 22 skills · 8 agents · Ricardo Braga &amp; Miguel Santos</p>
+  <p>MIT License · 23 skills · 8 agents · Ricardo Braga &amp; Miguel Santos</p>
   <div class="footer-links">
     <a href="https://github.com/RBraga01/Quality-Engineering-Skills" target="_blank">GitHub</a>
     <a href="https://chatgpt.com/g/g-6a22e9e03f8881918c35741d618bad54-quality-engineering-assistant" target="_blank">ChatGPT GPT</a>

--- a/docs/maintenance-checklist.md
+++ b/docs/maintenance-checklist.md
@@ -116,14 +116,26 @@ Triggered when content is changed in an existing `SKILL.md` file (either directl
 
 Triggered when any SKILL.md content changes (correction, version bump, new section).
 
-| # | File | What to change | Example |
-|---|------|----------------|---------|
-| 1 | `platforms/chatgpt/knowledge/<skill-name>.md` | Copy the updated SKILL.md verbatim over the knowledge file | `Copy-Item skills/planning/ppap/SKILL.md platforms/chatgpt/knowledge/ppap.md` |
-| 2 | `platforms/claude-ai/knowledge/<skill-name>.md` | Same — copy to claude-ai knowledge directory | `Copy-Item skills/planning/ppap/SKILL.md platforms/claude-ai/knowledge/ppap.md` |
+**Do not copy these files by hand.** Run the generator:
+
+```
+python scripts/sync_platform_knowledge.py --write
+```
+
+It regenerates both bundles from `skills/`, and `--check` (run by the Quality Check
+workflow on every push and PR) fails the build if they diverge.
+
+| # | Action | Notes |
+|---|--------|-------|
+| 1 | Run `python scripts/sync_platform_knowledge.py --write` | Regenerates `platforms/chatgpt/knowledge/` and `platforms/claude-ai/knowledge/` |
+| 2 | Stage the regenerated files in the same commit as the SKILL.md change | CI fails otherwise |
+| 3 | Adding a reference or asset file to a bundle? Add it to `EXTRA_FILES` in the script | Every entry is extra context loaded on every platform request — add deliberately |
 
 **Why this matters:** The ChatGPT GPT and Claude.ai Project load skills from these knowledge bundles. If the canonical SKILL.md is updated but the knowledge files are not, the platforms silently serve stale content.
 
-**Rule:** Every SKILL.md change that goes into a commit **must** have a corresponding knowledge file update staged in the same commit.
+This is not hypothetical. The instruction that used to sit here told you to `Copy-Item` each file individually, and it was not followed: on 2026-07-27 all 22 skill bundles and both reference bundles were still v1.0 snapshots taken *before* the v1.1 review round, so both platforms had been serving pre-review content — including errors the review had already corrected — for roughly seven weeks. A manual step performed 30+ times per release is a step that gets skipped.
+
+**Rule:** Every SKILL.md change that goes into a commit **must** have the regenerated bundles staged in the same commit.
 
 ---
 

--- a/platforms/chatgpt/knowledge/5why-root-cause.md
+++ b/platforms/chatgpt/knowledge/5why-root-cause.md
@@ -14,6 +14,12 @@ metadata:
   domain: quality-engineering
   subdomain: problem-solving
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: RBraga01
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015"
 ---
 
 # 5-Why Root Cause Analysis
@@ -175,3 +181,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 ## Reference files
 
 - [Chain validation guide](references/chain-validation.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @RBraga01 | Added dual-chain requirement (occurrence + escape), evidence status tracking |

--- a/platforms/chatgpt/knowledge/8d-problem-solving.md
+++ b/platforms/chatgpt/knowledge/8d-problem-solving.md
@@ -14,6 +14,12 @@ metadata:
   domain: quality-engineering
   subdomain: problem-solving
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: RBraga01
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015 / IATF 16949:2016"
 ---
 
 # 8D Problem Solving
@@ -264,3 +270,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 
 - [D0–D8 detailed guide](references/d0-d8-guide.md)
 - [8D report template](assets/8d-template.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @RBraga01 | Added Required Execution Checklist, D-level validation criteria, OEM gate rules |

--- a/platforms/chatgpt/knowledge/8d-report-writing.md
+++ b/platforms/chatgpt/knowledge/8d-report-writing.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iso-9001: "10.2"
   iatf-16949: "10.2.3"
   domain: quality-engineering
   subdomain: documentation
   industries: automotive,electronics
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015 / IATF 16949:2016"
 ---
 
 # 8D Customer Report Writing
@@ -253,3 +259,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 ## Reference files
 
 - [OEM-specific requirements](references/oem-formats.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @migmcc | Added OEM format requirements and customer submission checklists |

--- a/platforms/chatgpt/knowledge/8d-template.md
+++ b/platforms/chatgpt/knowledge/8d-template.md
@@ -1,3 +1,17 @@
+---
+name: 8d-template
+type: asset
+parent_skill: 8d-problem-solving
+author: RBraga01
+version: "1.0"
+status: approved
+created: "2026-06-01"
+last_updated: "2026-06-03"
+updated_by: RBraga01
+reviewed_by: RBraga01
+license: MIT
+---
+
 # 8D Report Template
 
 **8D Number:** ___________

--- a/platforms/chatgpt/knowledge/action-priority-ap.md
+++ b/platforms/chatgpt/knowledge/action-priority-ap.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iatf-16949: "8.3.3.3"
   aiag-reference: "AIAG-VDA FMEA Handbook 2019, Step 5, Table 5-3"
   domain: quality-engineering
   subdomain: risk-analysis
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "AIAG-VDA FMEA Handbook 2019"
 ---
 
 # Action Priority (AP) — AIAG-VDA 2019
@@ -31,7 +37,8 @@ Assign and audit Action Priority (AP) ratings correctly using the AIAG-VDA 2019 
 ☐ Confirm O is based on the Failure Cause with current prevention controls in place
 ☐ Confirm D is based on current detection controls for this Failure Mode
 ☐ All S, O, and D ratings are supported by data, field history, capability data, or documented engineering judgement — not guesses
-☐ Assign AP using the full AIAG-VDA AP table (see assets/ap-table.md) — not only the summary patterns in this skill
+☐ Assign AP using the full AP determination rules (see [ap-table.md](../pfmea-process/assets/ap-table.md)) — not only the summary patterns in this skill
+☐ For formal PPAP submissions, customer-facing FMEAs, or any disputed rating, confirm against your licensed AIAG-VDA FMEA Handbook — the rating criteria that make an S, O or D value defensible are in the handbook, not in this skill
 ☐ For every H-AP item: define a corrective action with owner and target date, or document a formal escalation rationale
 ☐ Reassess AP only after the corrective action is implemented and verified — not when only planned
 ☐ Verify Special Characteristics are rated S = 9 or 10
@@ -95,7 +102,7 @@ M-AP does not mean "no action needed." It means action is not mandatory, but the
 
 ## AP Assessment Workflow
 
-> This skill explains AP logic and decision patterns. Use the full AP table (assets/ap-table.md) for final rating assignment. Do not rely solely on the summary patterns below for disputed cases or formal PPAP submissions.
+> This skill explains AP logic and decision patterns. Use the full AP determination rules ([ap-table.md](../pfmea-process/assets/ap-table.md)) for final rating assignment. Do not rely solely on the summary patterns below for disputed cases or formal PPAP submissions — those require the rating criteria in your licensed AIAG-VDA FMEA Handbook.
 
 **Before assigning AP:** Do not assign AP unless S, O, and D are already justified based on the linked failure effect, failure cause, and current controls. AP is only as good as the ratings it is built on.
 
@@ -109,7 +116,7 @@ For each FC (Failure Cause) row in the PFMEA/DFMEA:
 
 3. Assign O (for this Failure Cause with current prevention controls)
 4. Assign D (for this Failure Mode with current detection controls)
-5. Look up AP in the full table (see assets/ap-table.md)
+5. Look up AP in the full table (see ../pfmea-process/assets/ap-table.md)
 ```
 
 **All S, O, and D ratings must be supported by test data, field history, capability data, or documented engineering judgement.**
@@ -206,3 +213,10 @@ At the start of each use, ask the user:
 > Default: A."
 
 Adapt all output sections to the chosen format. If the platform or session context already defines a format preference, skip this question.
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @migmcc | Polished AP classification logic, added OEM CSR requirements table |

--- a/platforms/chatgpt/knowledge/ap-table.md
+++ b/platforms/chatgpt/knowledge/ap-table.md
@@ -1,12 +1,42 @@
-# AIAG-VDA Action Priority (AP) Table
+---
+name: ap-table
+type: asset
+parent_skill: pfmea-process
+author: RBraga01
+version: "1.0"
+status: approved
+created: "2026-06-01"
+last_updated: "2026-06-03"
+updated_by: RBraga01
+reviewed_by: RBraga01
+license: MIT
+license-note: >-
+  MIT covers the original expression in this file. It does not extend to the
+  AIAG-VDA FMEA Handbook, which is a separately licensed third-party work.
+  See THIRD_PARTY_CONTENT.md.
+---
 
-Reference: AIAG-VDA FMEA Handbook 2019, Step 5, Table 5-3
+# Action Priority (AP) Determination Rules
 
-## How to read the table
+**What this file is.** An independent restatement of the Action Priority decision
+logic used in the AIAG-VDA FMEA methodology (2019 joint edition), expressed as
+banded rules. It is **not** a reproduction of the handbook's Action Priority
+table, and it does not replace it.
+
+**What this file is not.** The authoritative AP table enumerates every S/O/D
+combination and comes with the rating criteria tables that define what each S, O
+and D value means. Those criteria are what make a rating defensible in an audit,
+and they are not in this file. For formal PPAP submissions, customer-facing FMEA
+work, or any disputed rating, use your own licensed copy of the handbook.
+
+AIAG and VDA are trademarks of their respective owners. This project is not
+affiliated with, endorsed by, or certified by either organisation.
+
+## How to apply the rules
 
 1. Find the Severity (S) row
-2. Find the Occurrence (O) column range
-3. Find the Detection (D) range
+2. Find the Occurrence (O) band
+3. Find the Detection (D) band
 4. Read the Action Priority: **H** (High), **M** (Medium), **L** (Low)
 
 ## Absolute rules (override the table)
@@ -16,7 +46,7 @@ Reference: AIAG-VDA FMEA Handbook 2019, Step 5, Table 5-3
 | S = 9 or 10 | Always **H** — regardless of O and D |
 | S = 8, O = 4–10 | **H** if D ≥ 5; **M** if D ≤ 4 |
 
-## AP Table (AIAG-VDA 2019 summary)
+## AP decision rules (banded)
 
 | S | O | D | AP |
 |---|---|---|----|

--- a/platforms/chatgpt/knowledge/apqp.md
+++ b/platforms/chatgpt/knowledge/apqp.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: apqp
 description: >-
   Advanced Product Quality Planning (APQP) — plan and track a new product launch through all 5 phases,

--- a/platforms/chatgpt/knowledge/car-corrective-action.md
+++ b/platforms/chatgpt/knowledge/car-corrective-action.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iso-9001: "10.2"
   iatf-16949: "10.2.3"
   domain: quality-engineering
   subdomain: documentation
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-04"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015"
 ---
 
 # Corrective Action Request (CAR) Writing
@@ -26,7 +32,7 @@ A CAR is written in response to:
 - An internal or external audit finding (Major or Minor non-conformance)
 - A recurring non-conformance requiring systemic correction
 
-The CAR is the documented evidence that the problem was analysed, corrected, and prevented from recurring. ISO 9001 §10.2.1 requires documented information of the actions taken and their results.
+The CAR is the documented evidence that the problem was analysed, corrected, and prevented from recurring. ISO 9001 §10.2.1 requires documented information of the actions taken and their results. For IATF 16949 audit Major NCs, CARs must typically be closed within 90 days; check the applicable CSR for customer-specific closure deadlines.
 
 ## Key distinction from NCR
 
@@ -39,6 +45,8 @@ The CAR is the documented evidence that the problem was analysed, corrected, and
 
 A CAR references the NCR but extends it into corrective action territory.
 
+---
+
 ## CAR structure
 
 ### 1. Header
@@ -50,11 +58,12 @@ A CAR references the NCR but extends it into corrective action territory.
 | Date opened | |
 | Owner | Responsible person (name, not function) |
 | Target closure date | |
+| Closure authority | Named person with authority to close this CAR (quality manager or equivalent) |
 | Actual closure date | (filled on closure) |
 
 ### 2. Problem summary
 
-One or two sentences summarising the NCR or finding. Objective, factual.
+One or two sentences summarising the NCR or finding. Objective, factual. Must match the NCR description exactly — no new interpretation.
 
 Example:
 > "47 of 200 connector units in lot 2026-05-12-A had pin insertion depth 0.6–1.5 mm below lower specification limit (5.0 ± 0.3 mm). Detected at incoming inspection (NCR-2026-0047)."
@@ -88,7 +97,13 @@ Why: Not detected at our outgoing inspection → Why: no depth measurement in ou
 inspection plan → Root cause: Control Plan does not include pin depth at outgoing.
 ```
 
-**Validation:** state how the root cause was confirmed (reproduction test, data correlation, physical evidence).
+**Validation:** state how the root cause was confirmed. Acceptable validation methods:
+- Reproduction test (demonstrated that removing/restoring the root cause produces/prevents the defect)
+- Data correlation (statistical relationship between root cause variable and defect occurrence)
+- Physical evidence (inspection of the failed part or process reveals the causal mechanism)
+- Direct record review (confirms the absence of the required control)
+
+A root cause supported only by team opinion (not validated by evidence) cannot be used as the basis for CAR closure.
 
 ### 5. Corrective actions
 
@@ -127,17 +142,26 @@ This is where most CARs fail. The action is implemented, but nobody checks wheth
 3. **Volume/duration:** what sample size or time period constitutes sufficient evidence?
 4. **Target:** what result confirms the action was effective?
 
-**Typical VOE approach for a process change:**
-- Produce a minimum of [300 units / 30 shifts / 3 months] with the new process
-- Zero recurrence of the original defect mode during this period
-- Confirm with inspection data
+**VOE minimum volume guidance:**
+- For a defect with known base rate: the VOE sample must be large enough to observe at least one recurrence if the action had failed. Example: if baseline defect rate was 5%, a zero-defect sample of 60 units gives 95% confidence the rate is now below 5%.
+- For process parameter changes: minimum 30 consecutive production cycles under the new conditions, or as defined by the Control Plan sampling frequency × 3 periods.
+- For detection control improvements: minimum one full inspection cycle of the affected product family with zero escapes.
+- Minimum in all cases: state the volume used and the basis for choosing it. "Zero defects in 10 units" is not a valid VOE for a high-volume process.
 
 **VOE result:**
 - Record the actual results after the monitoring period
 - State: Effective / Not effective
 - If not effective: return to root cause analysis and repeat
 
-### 8. Systemic prevention and horizontal deployment
+### 8. AP revision (AIAG-VDA, if applicable)
+
+If the non-conformance relates to a PFMEA failure mode with an Action Priority (AP) rating:
+
+- After verified implementation of the corrective action, the PFMEA must be updated with a revised S, O, and/or D rating
+- The revised AP (AP-revised) must reflect the improvement — it must be lower than the original AP or documented with justification if unchanged
+- Revised AP is recorded only after VOE is complete, not at the time of action planning
+
+### 9. Systemic prevention and horizontal deployment
 
 Ask: could this same root cause exist in similar parts, processes, or product families?
 
@@ -146,7 +170,7 @@ If yes:
 - Document the actions taken to extend the corrective action
 - Evidence that horizontal deployment is complete
 
-### 9. Lessons learned
+### 10. Lessons learned
 
 One or two sentences capturing the key learning for future reference:
 
@@ -158,22 +182,31 @@ File in the lessons learned register and reference in PFMEA update.
 
 ## Closure criteria
 
-A CAR may only be closed when ALL of the following are true:
-- [ ] Root causes of occurrence and escape are documented with evidence
-- [ ] Corrective actions are implemented and documented
-- [ ] VOE is complete and confirms effectiveness
-- [ ] PFMEA is updated (revised failure mode entry)
+A CAR may only be closed when ALL of the following are true, and the closure authority (named in the header) has signed off:
+
+- [ ] Root causes of occurrence and escape are documented with validation evidence
+- [ ] Corrective actions are implemented and documented with revision numbers and approval dates
+- [ ] VOE is complete with documented sample volume and confirms effectiveness
+- [ ] PFMEA is updated (revised failure mode entry, revised AP if applicable)
 - [ ] Control Plan is updated (if detection control changed)
 - [ ] Work Instructions are updated (if process control changed)
 - [ ] Horizontal deployment is documented
-- [ ] Customer notified of closure (if CAR was triggered by customer complaint)
+- [ ] Customer notified of closure (if CAR was triggered by customer complaint or CSR-required notification)
+- [ ] Closure authority sign-off obtained
+
+---
 
 ## Common mistakes
 
 - **"Retrain operators"** as a corrective action for human error — this is never sufficient alone; the system that allowed the error must be changed
 - **Closing without VOE** — the most common reason for recurring non-conformances
+- **VOE on insufficient sample** — "zero defects in 5 units" is not effectiveness verification; define the minimum volume before collecting data
 - **Implementing actions without updating PFMEA and Control Plan** — next audit will find the gap
 - **Generic actions** — "review procedures" → not specific; must state which procedure, revised to say what, by whom, by when
+- **Closing without named authority sign-off** — any team member closing a CAR without defined authority is a governance gap
+- **Missing AP revision** — when PCA addresses a PFMEA failure mode, the revised AP must be recorded after VOE
+
+---
 
 ## Output Format
 
@@ -187,3 +220,10 @@ At the start of each use, ask the user:
 > Default: A."
 
 Adapt all output sections to the chosen format. If the platform or session context already defines a format preference, skip this question.
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-04 | @migmcc | Expanded CAR linkage to D5-D6, added effectiveness verification requirements |

--- a/platforms/chatgpt/knowledge/control-plan-builder.md
+++ b/platforms/chatgpt/knowledge/control-plan-builder.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: control-plan-builder
 description: >-
   Interactive Control Plan builder — takes PFMEA failure modes and process flow steps as input and

--- a/platforms/chatgpt/knowledge/control-plan.md
+++ b/platforms/chatgpt/knowledge/control-plan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: control-plan
 description: >-
   Control Plan — build, review, or audit a Prototype, Pre-launch, or Production Control Plan linked

--- a/platforms/chatgpt/knowledge/d0-d8-guide.md
+++ b/platforms/chatgpt/knowledge/d0-d8-guide.md
@@ -1,3 +1,17 @@
+---
+name: d0-d8-guide
+type: reference
+parent_skill: 8d-problem-solving
+author: RBraga01
+version: "1.0"
+status: approved
+created: "2026-06-01"
+last_updated: "2026-06-03"
+updated_by: RBraga01
+reviewed_by: RBraga01
+license: MIT
+---
+
 # D0–D8 Reference Guide
 
 Complete reference for the Eight Disciplines (8D) problem-solving methodology.
@@ -206,7 +220,7 @@ Stop the non-conforming product from reaching the customer while D4–D5 are in 
 | Stellantis | 8D (MAQMSR) | Recommended | SQS Portal |
 | GM | Global 8D | Recommended | Covisint |
 
-See [oem-formats](../../documentation/8d-report-writing/references/oem-formats.md) for full detail.
+See [oem-formats](../../../documentation/8d-report-writing/references/oem-formats.md) for full detail.
 
 ---
 

--- a/platforms/chatgpt/knowledge/dfmea-design.md
+++ b/platforms/chatgpt/knowledge/dfmea-design.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: dfmea-design
 description: >-
   Build a design risk analysis, DFMEA worksheet, or interface analysis using the AIAG-VDA

--- a/platforms/chatgpt/knowledge/dmaic.md
+++ b/platforms/chatgpt/knowledge/dmaic.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: dmaic
 description: >-
   DMAIC (Define-Measure-Analyze-Improve-Control) — Six Sigma structured problem-solving for

--- a/platforms/chatgpt/knowledge/dvp-test-plan.md
+++ b/platforms/chatgpt/knowledge/dvp-test-plan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: dvp-test-plan
 description: >-
   Design Verification Plan and Report (DVP&R) — build or review a test plan that links each DFMEA

--- a/platforms/chatgpt/knowledge/fishbone-analysis.md
+++ b/platforms/chatgpt/knowledge/fishbone-analysis.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iso-9001: "10.2"
   iatf-16949: "10.2.3"
   domain: quality-engineering
   subdomain: problem-solving
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-04"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015"
 ---
 
 # Fishbone (Ishikawa) Analysis
@@ -30,9 +36,22 @@ Typical use: 8D D4 brainstorming session, CAPA root cause investigation, initial
 - Cross-functional team (quality, production, engineering at minimum)
 - Access to the process, machine, or product where defect occurred
 
+## Required Fishbone Checklist
+
+☐ Problem statement defined and agreed before starting — no cause language in the problem statement
+☐ All 6M categories addressed — at least one entry per M, or documented justification if a category is not applicable
+☐ Brainstorming completed before any evaluation or elimination — do not evaluate while generating
+☐ Every cause classified as Confirmed, Probable, or Unlikely using objective evidence — not opinion alone
+☐ Confirmed = supported by data or physical evidence; Probable = logical, consistent with Is/Is-Not, not yet confirmed; Unlikely = contradicted by data
+☐ Confirmed and Probable causes cross-checked against existing PFMEA failure cause entries before proceeding to 5-Why
+☐ Each Confirmed or Probable cause carries forward to its own 5-Why chain
+☐ After root cause confirmed: horizontal deployment check — could the same cause exist in similar parts, processes, or product families?
+
+---
+
 ## The 6M Framework
 
-The six main "bones" of the fish:
+The six main "bones" of the fish. **All six must be addressed.** If a category genuinely does not apply, document: "No causes identified in this category after structured team review — not applicable because [reason]."
 
 ### 1. Man (Human Factors)
 
@@ -91,6 +110,8 @@ Questions to ask:
 - Are there seasonal patterns?
 - Does the cleanroom or ESD environment meet requirements?
 
+---
+
 ## Workflow
 
 ### Step 1 — Draw the diagram
@@ -101,24 +122,35 @@ Write the problem (effect) at the head (right side). Draw the spine. Add six mai
 
 For each M category: "What in [M] could cause [the problem]?"
 
-Capture all ideas without judgment — quantity first, evaluation second.
+Capture all ideas without judgment — quantity first, evaluation second. **Do not evaluate or discard during brainstorming.** Allocate 30–60 minutes minimum. Time pressure is the most common reason causes are missed.
 
 Add each cause as a sub-bone to the relevant M category. Sub-bones can branch further (cause of a cause).
 
 ### Step 3 — Evaluate and prioritise
 
 Mark each cause as:
-- **Confirmed** (supported by data or direct evidence)
-- **Probable** (logical but not yet confirmed)
-- **Unlikely** (logical argument against it)
+- **Confirmed** (supported by data or direct physical evidence — not opinion)
+- **Probable** (logical, consistent with the Is/Is-Not pattern, but not yet confirmed by data)
+- **Unlikely** (contradicted by data or the Is/Is-Not pattern)
 
-Discard unlikely causes. Investigate confirmed and probable causes.
+Discard Unlikely causes. Investigate Confirmed and Probable causes. A cause cannot be classified as Confirmed without objective evidence (measurement data, physical demonstration, reproduction test, or direct record review).
 
-### Step 4 — Connect to 5-Why
+### Step 4 — PFMEA cross-check
 
-For each confirmed or probable cause, run a [5-Why chain](../5why-root-cause/) to reach the systemic root cause.
+Before proceeding to 5-Why, cross-check Confirmed and Probable causes against the existing PFMEA:
+
+- Is this failure cause already documented in the PFMEA? If yes, was its detection or prevention control supposed to prevent this defect?
+- If the PFMEA did not capture this cause, flag it — the PFMEA must be updated after the root cause is confirmed.
+
+### Step 5 — Connect to 5-Why
+
+For each Confirmed or Probable cause, run a [5-Why chain](../5why-root-cause/) to reach the systemic root cause.
 
 The fishbone identifies candidate causes. The 5-Why validates and deepens them.
+
+After root cause is confirmed: assess whether the same cause could exist in similar parts, processes, or product families. Document horizontal deployment actions if applicable.
+
+---
 
 ## Output format
 
@@ -133,12 +165,20 @@ Document the fishbone as a table (easier to include in reports than a diagram):
 | Measurement | Gauge repeatability | GR&R = 8% — acceptable | No |
 | Environment | Temperature | Controlled at 22°C ± 2°C — stable | No |
 
+All 6M categories must appear in the table. If a category has no entries after structured brainstorming, document: "No causes identified in this category after structured team review."
+
+---
+
 ## Common mistakes
 
 - **Brainstorming under time pressure** — causes are missed; allocate 30–60 minutes minimum
 - **Stopping at first-level causes** — "machine not calibrated" is a cause, but add sub-bone: why was it not calibrated?
-- **Not using data to confirm/discard** — every cause must be validated, not just listed
+- **Not using data to confirm/discard** — every cause must be validated against objective evidence, not just listed
 - **Using fishbone as the root cause** — fishbone finds candidate causes; 5-Why finds root cause
+- **Skipping categories** — if a category is left blank without justification, the analysis is incomplete and may miss the real cause
+- **Classifying causes as Confirmed based on team opinion** — Confirmed requires evidence; without it, classify as Probable and plan verification
+
+---
 
 ## Output Format
 
@@ -152,3 +192,10 @@ At the start of each use, ask the user:
 > Default: A."
 
 Adapt all output sections to the chosen format. If the platform or session context already defines a format preference, skip this question.
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-04 | @migmcc | Polished 6M categories, added validation criteria and 5-Why integration |

--- a/platforms/chatgpt/knowledge/iatf-16949-audit.md
+++ b/platforms/chatgpt/knowledge/iatf-16949-audit.md
@@ -9,11 +9,17 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iatf-16949: "9.2.2"
   domain: quality-engineering
   subdomain: audit
   industries: automotive,electronics
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "IATF 16949:2016"
 ---
 
 # IATF 16949:2016 Internal Audit — Supplemental Requirements
@@ -361,3 +367,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 ## Reference files
 
 - [IATF supplemental requirements checklist](references/supplemental-requirements.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @migmcc | Added supplemental requirements reference and CSR audit coverage |

--- a/platforms/chatgpt/knowledge/is-is-not-scoping.md
+++ b/platforms/chatgpt/knowledge/is-is-not-scoping.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iso-9001: "10.2"
   iatf-16949: "10.2.3"
   domain: quality-engineering
   subdomain: problem-solving
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-04"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015"
 ---
 
 # Is/Is-Not Problem Scoping
@@ -23,6 +29,24 @@ metadata:
 Use Is/Is-Not at the start of any quality investigation to precisely define what the problem IS and what it IS NOT. This scoping prevents wasted investigation effort and immediately eliminates hypotheses that cannot explain the observed IS/IS-NOT pattern.
 
 Most effective in 8D D2 (problem description), CAPA scoping, and any situation where the defect is intermittent, batch-specific, or location-specific.
+
+## Critical rule — facts only
+
+**The IS column contains only documented, measured facts.** Hypotheses, assumptions, and opinions belong in the hypothesis list, not in the matrix. If a cell contains an assumption rather than a fact, the entire analysis is compromised.
+
+If data is not yet available: mark the cell as "Unknown — to be investigated" and identify what investigation is needed before proceeding.
+
+## Required Is/Is-Not Checklist
+
+☐ All five dimensions completed — What, Which, Where, When, How many — or marked "Unknown — to be investigated"
+☐ IS column contains only documented facts and measured values — no assumptions, no hypotheses
+☐ IS NOT column completed for each dimension — this is where hypotheses get eliminated; do not leave blank
+☐ Vague IS statements converted to specific facts with numbers (batch, quantity, percentage)
+☐ At least three hypotheses generated and tested against the full matrix
+☐ Eliminated hypotheses documented with the specific IS/IS-NOT entry that contradicts them
+☐ Is/Is-Not output referenced in the NCR problem description and carried forward to Fishbone or 5-Why
+
+---
 
 ## The Is/Is-Not Matrix
 
@@ -70,9 +94,11 @@ Example: "IS: First observed 2026-05-12, all shifts. IS NOT: Before 2026-05-10."
 |----|--------|
 | Defect rate (parts per million, percentage) | What rate is NOT observed |
 | Quantity affected | Quantity not affected |
-| Trend (increasing, stable, decreasing) | |
+| Trend (increasing, stable, decreasing) | No trend in unaffected population |
 
 Example: "IS: 23.5% of parts in affected batches (47/200). IS NOT: Any defects in batches before 2026-05-10 (0/500 inspected)."
+
+---
 
 ## Using the matrix to eliminate hypotheses
 
@@ -88,31 +114,42 @@ Once the matrix is complete, generate hypotheses and test each against the IS/IS
 - IS NOT: Not found at our outgoing inspection → **contradicts** (if we measure 100%, our gauge would catch it)
 → Hypothesis eliminated
 
-Any hypothesis that cannot explain ALL items in the IS and IS-NOT columns is eliminated or requires modification.
+Any hypothesis that cannot explain ALL items in the IS and IS-NOT columns is eliminated or requires modification. Document the specific contradiction for each eliminated hypothesis.
+
+---
 
 ## Workflow
 
 1. Gather data: inspection records, production records, customer complaint details
-2. Fill in the matrix — only include facts, not hypotheses
+2. Fill in the matrix — only include facts, not hypotheses; mark gaps as "Unknown — to be investigated"
 3. Identify the "clue" — what distinctive pattern appears (specific batch, specific location, specific time)?
-4. List candidate hypotheses
+4. List candidate hypotheses (minimum three)
 5. Test each hypothesis against the full matrix
-6. Eliminate those that contradict the data
+6. Eliminate those that contradict the data — document the contradiction
 7. Carry forward surviving hypotheses into Fishbone or 5-Why
+8. Reference the Is/Is-Not matrix in the NCR problem description — the IS "What" entry is the basis for the NCR non-conformance description
+
+---
 
 ## Output format
 
 A complete Is/Is-Not matrix (table format) with:
-- All five dimensions completed with specific facts
-- Surviving hypotheses listed with explanation of why they fit the matrix
-- Eliminated hypotheses listed with the specific contradiction
+- All five dimensions completed with specific facts (or "Unknown — to be investigated")
+- Surviving hypotheses listed with explanation of why they fit the full matrix
+- Eliminated hypotheses listed with the specific contradiction that rules each one out
+
+---
 
 ## Common mistakes
 
-- **Listing assumptions as IS** — only documented, measured facts go in the matrix
-- **Leaving cells empty** — if you don't know, mark "unknown — to be investigated"
+- **Listing assumptions as IS** — only documented, measured facts go in the matrix; assumptions generate false hypotheses
+- **Leaving cells empty** — if you don't know, mark "Unknown — to be investigated"; empty cells mean the analysis is incomplete
 - **Not using IS NOT** — the IS NOT column is where hypotheses get eliminated; skipping it wastes investigation time
-- **Vague IS statements** — "some parts are bad" → must be: "23.5% of batch 2026-05-12 are non-conforming on dimension X"
+- **Vague IS statements** — "some parts are bad" → must be: "23.5% of batch 2026-05-12 are non-conforming on dimension X (47/200 units measured)"
+- **Testing only one or two hypotheses** — generate at least three before starting elimination; premature narrowing misses the real cause
+- **Not linking output to NCR** — the Is/Is-Not "What IS" entry must match the NCR problem description exactly
+
+---
 
 ## Output Format
 
@@ -126,3 +163,10 @@ At the start of each use, ask the user:
 > Default: A."
 
 Adapt all output sections to the chosen format. If the platform or session context already defines a format preference, skip this question.
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-04 | @migmcc | Expanded Is/Is-Not table criteria and D2 integration guidance |

--- a/platforms/chatgpt/knowledge/iso-9001-internal-audit.md
+++ b/platforms/chatgpt/knowledge/iso-9001-internal-audit.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iso-9001: "9.2"
   iatf-16949: "9.2.2"
   domain: quality-engineering
   subdomain: audit
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015"
 ---
 
 # ISO 9001:2015 Internal Audit
@@ -414,3 +420,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 ## Reference files
 
 - [Clause-by-clause question bank](references/clause-questions.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @migmcc | Expanded clause-by-clause question bank and evidence anchors |

--- a/platforms/chatgpt/knowledge/msa-gauge-rr.md
+++ b/platforms/chatgpt/knowledge/msa-gauge-rr.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: msa-gauge-rr
 description: >-
   Measurement System Analysis (MSA) and Gauge Repeatability & Reproducibility (Gauge R&R) — plan,

--- a/platforms/chatgpt/knowledge/ncr-writing.md
+++ b/platforms/chatgpt/knowledge/ncr-writing.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iso-9001: "8.7"
   iatf-16949: "8.7.1"
   domain: quality-engineering
   subdomain: documentation
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015"
 ---
 
 # Non-Conformance Report (NCR) Writing
@@ -202,3 +208,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 ## Reference files
 
 - [NCR template](assets/ncr-template.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @migmcc | Expanded severity classification criteria and disposition guidance |

--- a/platforms/chatgpt/knowledge/oem-formats.md
+++ b/platforms/chatgpt/knowledge/oem-formats.md
@@ -1,3 +1,17 @@
+---
+name: oem-formats
+type: reference
+parent_skill: 8d-report-writing
+author: RBraga01
+version: "1.0"
+status: approved
+created: "2026-06-01"
+last_updated: "2026-06-03"
+updated_by: migmcc
+reviewed_by: RBraga01
+license: MIT
+---
+
 # OEM 8D Report Formats — Reference
 
 Differences between OEM-specific 8D submission formats.

--- a/platforms/chatgpt/knowledge/oem-requirements.md
+++ b/platforms/chatgpt/knowledge/oem-requirements.md
@@ -1,3 +1,17 @@
+---
+name: oem-requirements
+type: reference
+parent_skill: action-priority-ap
+author: RBraga01
+version: "1.0"
+status: approved
+created: "2026-06-01"
+last_updated: "2026-06-03"
+updated_by: migmcc
+reviewed_by: RBraga01
+license: MIT
+---
+
 # OEM Action Priority Requirements — Reference
 
 OEM-specific requirements for Action Priority (AP) in PFMEA and DFMEA.

--- a/platforms/chatgpt/knowledge/pdca-improvement.md
+++ b/platforms/chatgpt/knowledge/pdca-improvement.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: pdca-improvement
 description: >-
   Run a PDCA cycle, Plan Do Check Act improvement cycle, or structured improvement project.

--- a/platforms/chatgpt/knowledge/pfmea-process.md
+++ b/platforms/chatgpt/knowledge/pfmea-process.md
@@ -16,6 +16,12 @@ metadata:
   domain: quality-engineering
   subdomain: risk-analysis
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: RBraga01
+  reviewed_by: RBraga01
+  standard_edition: "AIAG-VDA FMEA Handbook 2019"
 ---
 
 # Process FMEA (PFMEA) — AIAG-VDA 2019
@@ -262,3 +268,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 
 - [AIAG-VDA 2019 step-by-step guide](references/aiag-vda-2019.md)
 - [Action Priority table](assets/ap-table.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @RBraga01 | Expanded 7-step workflow with AP gate requirements and PPAP integration |

--- a/platforms/chatgpt/knowledge/ppap-checker.md
+++ b/platforms/chatgpt/knowledge/ppap-checker.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: ppap-checker
 description: >-
   Interactive PPAP completeness checker — walks through all 18 PPAP elements for a given submission

--- a/platforms/chatgpt/knowledge/ppap.md
+++ b/platforms/chatgpt/knowledge/ppap.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: ppap
 description: >-
   Production Part Approval Process (PPAP) — verify PPAP submission level, audit all 18 elements,

--- a/platforms/chatgpt/knowledge/quality-problem-zeroing.md
+++ b/platforms/chatgpt/knowledge/quality-problem-zeroing.md
@@ -1,0 +1,376 @@
+---
+name: quality-problem-zeroing
+description: >-
+  Run quality problem zeroing, perform 双归零 (double-five zeroing), write a
+  technical zeroing report, write a management zeroing report, or close an
+  aerospace quality problem under GB/T 29076—2021. Covers problem reporting,
+  emergency response, team formation, technical zeroing (定位准确、机理清楚、问题复现、
+  措施有效、举一反三), management zeroing (过程清楚、责任明确、措施落实、严肃处理、
+  完善规章), evidence gates, review, and closure. Use for aerospace or complex
+  equipment failures, defects, accidents, repeated problems, human-responsibility
+  problems, and issues requiring a formal closed-loop investigation.
+license: MIT
+metadata:
+  author: Crow12138
+  version: "1.0"
+  iso-9001: "10.2 (supporting)"
+  gbt-29076: "2021"
+  domain: quality-engineering
+  subdomain: problem-solving
+  industries: aerospace,defense,aviation,complex-equipment,manufacturing
+  status: approved
+  created: "2026-07-04"
+  last_updated: "2026-07-04"
+  updated_by: Crow12138
+  reviewed_by: RBraga01
+  standard_edition: "GB/T 29076—2021"
+---
+
+# Quality Problem Zeroing
+
+## Goal
+
+Close a quality problem with objective evidence that:
+
+1. Locates and explains the technical failure;
+2. Removes every confirmed root cause and verifies the result;
+3. Identifies and repairs management weaknesses where required;
+4. Extends the learning to other exposed products, processes, and organizations; and
+5. Leaves no action, evidence, approval, or known residual risk hidden at closure.
+
+GB/T 29076—2021 is the controlling source for scope, sequence, terminology, and closure.
+Treat other methods and publications as supporting guidance only. Read the
+[standard method guide](references/gbt-29076-2021-method-guide.md) whenever a
+formal scope decision, report, or closure review is required.
+
+## When to Use
+
+Use this skill for an aerospace or complex-equipment quality problem that requires formal
+technical zeroing, management zeroing, double-five zeroing, an Annex A-aligned report, or a
+closure review. It is especially relevant to failures, defects, accidents, batch problems,
+repeated problems, field or delivered-product issues, human-responsibility problems, and
+problems caused by missing or inadequate rules.
+
+Use a narrower root-cause skill when the user only needs one analysis tool. Use 8D instead
+when the customer or sector mandates an 8D response, then cross-check whether the same event
+also requires GB/T 29076—2021 zeroing.
+
+## Required Execution Checklist
+
+- [ ] Record the product, problem phenomenon, operating state, time, location, environment, detector, and affected parties.
+- [ ] Protect the scene, product state, records, data, and physical evidence when safe to do so.
+- [ ] Assess safety, property, mission, delivered-product, and escalation risk immediately.
+- [ ] Identify, segregate, stop, recall, or inspect suspect product as required.
+- [ ] Form a cross-functional team with a named leader, authority, resources, and stakeholder representation.
+- [ ] Decide and document whether technical zeroing, management zeroing, or both apply.
+- [ ] Start technical zeroing first when both apply; never substitute it for management zeroing.
+- [ ] Build an evidence-backed technical causal chain from the lowest failed unit to the observed effect.
+- [ ] Identify all root causes; keep unproven explanations labelled as hypotheses.
+- [ ] Reproduce or otherwise verify the problem mechanism using an approved method.
+- [ ] Implement correction and root-cause corrective actions with owners and dates.
+- [ ] Verify effectiveness, sufficiency, and adverse effects before ending emergency controls.
+- [ ] Complete horizontal deployment across relevant products, processes, and organizations.
+- [ ] Reconstruct the management process and assign responsibility from duties and evidence.
+- [ ] Implement management actions and embed them in controlled rules, standards, or procedures.
+- [ ] Complete the required report, evidence list, signatures, and independent review.
+- [ ] Close only after all actions are complete, effectiveness is verified, and residual issues are explicit.
+
+## Workflow
+
+### 1. Report and preserve the problem
+
+Create the initial problem record before analysis changes the evidence. Capture:
+
+- Product name, identifier, batch, configuration, development or service stage, and responsible organizations;
+- Exact phenomenon, expected requirement, actual result, operating state, sequence, time, location, and environment;
+- Who detected the problem and how it was detected;
+- Available logs, measurements, photographs, samples, remains, test equipment state, and operator records;
+- Actual and potential effect on safety, mission, customer, schedule, cost, performance, and delivered product.
+
+Do not dismantle, clean, power-cycle, overwrite logs, swap parts, or repeat a destructive
+test until the evidence impact is assessed and the action is authorized.
+
+### 2. Apply emergency response
+
+When harm may continue or worsen:
+
+1. Identify and isolate suspect product;
+2. Stop work, delivery, use, or recall product where justified;
+3. Check related stock and the potentially affected population;
+4. Apply a temporary control against the apparent cause;
+5. Assess downstream and delivered-product risk;
+6. Confirm severity and notify affected internal and external parties.
+
+Keep emergency response separate from permanent corrective action. Remove it only after a
+more effective root-cause action is implemented and verified.
+
+### 3. Form and govern the team
+
+Include functions that own or understand the affected design, process, test, production,
+quality, supplier, use, and customer interfaces. Name:
+
+- The team leader and decision authority;
+- Each member's responsibility;
+- Required resources, constraints, milestones, communication cadence, and escalation route;
+- Customer, supplier, or other stakeholder representatives where affected.
+
+The quality function controls the plan, conformity check, review, action tracking, and
+retention of evidence. The responsible organization performs the investigation.
+
+### 4. Decide the zeroing route
+
+Apply **technical zeroing** when technical causes or consequences fall within the standard's
+scope, including significant design, production, test, field, delivered-product, batch,
+repeat, cost, schedule, performance, effectiveness, or system-application issues.
+
+Apply **management zeroing** to:
+
+- Repeated quality problems;
+- Human-responsibility problems such as knowingly disregarding a rule or violating an operation;
+- Problems caused by missing or inadequate rules;
+- Problems designated for management zeroing by the authorized management system.
+
+If both scopes apply, perform both and begin with technical zeroing. Record the route,
+severity level, responsible organization, target dates, and rationale. Do not assume every
+technical issue automatically requires punishment or management zeroing.
+
+### 5. Perform technical zeroing
+
+#### 5.1 Locate exactly — 定位准确
+
+Determine the exact process, product, assembly, component, part, electronic component,
+software element, interface, test equipment, or operation where the problem originates.
+Reach the lowest failed unit supported by evidence and state its abnormal condition.
+
+Check whether the source is the product, support equipment, test method, environment, or
+operation. Use controlled substitution only when it preserves evidence and its result is
+not mistaken for proof of mechanism.
+
+**Gate:** The location and affected boundary are specific, evidence-backed, communicated,
+and accepted by relevant parties. “The system failed” or “the supplier part was bad” does
+not pass.
+
+#### 5.2 Explain the mechanism — 机理清楚
+
+Build the causal chain from abnormal factor to final phenomenon. Identify all root causes
+and explain the physical, chemical, electrical, software, human-system, or process mechanism.
+Analyze the problem from three views:
+
+- **Product:** design, material, component, interface, software, equipment, and environment;
+- **Process:** requirements, design, procurement, production, inspection, test, change,
+  delivery, use, maintenance, and rework;
+- **Organization:** responsibility, competence, communication, resources, oversight, and rules.
+
+Use evidence to eliminate alternatives. Suitable tools include engineering analysis, failure
+analysis, statistics, FTA, FMEA, Fishbone, 5-Why, process analysis, DOE, and comparison.
+
+**Gate:** Every claimed root cause has objective support, alternative explanations have a
+documented disposition, and the causal chain explains all material observations.
+
+#### 5.3 Reproduce or verify — 问题复现
+
+Prepare and approve a verification plan defining:
+
+- Hypothesis and expected phenomenon;
+- Test article and controlled configuration;
+- Variables, realistic conditions, instrumentation, data to collect, and acceptance criteria;
+- Safety limits, stop criteria, responsibilities, and required approvals.
+
+Execute the plan, preserve raw records, analyze results, and obtain stakeholder agreement.
+Prefer a controlled, mechanism-driven reproduction over an uncontrolled repeat.
+
+For obvious one-off damage, destructive modes, or conditions that cannot be reproduced,
+document why a reproduction test is inappropriate and use theory, analysis, simulation,
+inspection, or an equivalent verification method. Do not convert “not reproduced” into
+“no problem.”
+
+**Gate:** The result confirms or rejects the location and mechanism. A failed confirmation
+returns the investigation to localization or mechanism analysis.
+
+#### 5.4 Prove effective measures — 措施有效
+
+Separate:
+
+- **Correction:** removes the detected problem from affected product;
+- **Corrective action:** removes each root cause to prevent recurrence;
+- **Preventive or deployment action:** protects similar products not yet affected.
+
+For every root cause, define a specific, measurable, executable, and verifiable action with
+an owner, due date, required resources, affected configuration, and verification plan.
+Evaluate whether each action may create a new or worse risk.
+
+Implement approved actions in controlled design, process, test, software, training, or
+standard documents. Compare post-action results with the original problem evidence.
+
+**Gate:** Evidence proves the actions are effective and sufficiently cover the operating
+range without unacceptable adverse effects. If not, return to mechanism analysis.
+
+#### 5.5 Extend the learning — 举一反三
+
+Search for the same or similar mechanism across:
+
+- The affected unit, batch, produced items, work in progress, and not-yet-produced items;
+- Related parts, interfaces, software, equipment, processes, suppliers, and product families;
+- Other programs, departments, and organizations exposed to the same cause.
+
+State the search population, method, findings, decisions, actions, owners, and evidence.
+Issue lessons learned or alerts through the quality function. Embed approved learning in
+design rules, process instructions, test requirements, training, databases, and tools.
+
+**Gate:** Horizontal deployment is based on mechanism and exposure, not merely on the same
+part number, and every finding has a disposition.
+
+### 6. Perform management zeroing
+
+#### 6.1 Make the process clear — 过程清楚
+
+Reconstruct the complete event timeline and the process that created and detected the
+problem. Compare required versus actual activities, records, decisions, controls, and
+handoffs. Identify management weaknesses or gaps.
+
+#### 6.2 Make responsibility explicit — 责任明确
+
+Assign organizational and individual responsibility from documented duties, authority,
+actions, omissions, and evidence. Distinguish direct and indirect, primary and secondary,
+leadership and execution responsibility. Do not use responsibility analysis as a substitute
+for systemic root-cause analysis.
+
+#### 6.3 Implement management measures — 措施落实
+
+Address every management weakness with specific, checkable actions. Define the responsible
+department and person, completion date, resources, implementation evidence, and effectiveness
+check. Plan and fund medium- and long-term actions explicitly.
+
+#### 6.4 Treat the problem seriously — 严肃处理
+
+Use the event to educate personnel and improve management. Apply training, communication,
+coaching, or other organizational learning as appropriate. Apply administrative or economic
+penalties only under applicable rules for confirmed repeated problems, human-responsibility
+problems, falsification, or concealment. Recognize proactive discovery and effective
+prevention where organizational policy allows.
+
+#### 6.5 Perfect the rules — 完善规章
+
+Convert management actions into controlled management-system documents, standards,
+procedures, work instructions, or governance mechanisms. Define revision content, owner,
+approval, effective date, deployment, training, and compliance verification.
+
+**Management gate:** The process, responsibility, actions, treatment, and rules are each
+supported by evidence and address the identified management causes.
+
+### 7. Report, review, and close
+
+Use the [zeroing report template](assets/zeroing-report-template.md). For formal work, include
+the report sections and evidence described in Annex A of GB/T 29076—2021.
+
+Before closure, an authorized review must verify:
+
+- Route selection and scope were correct;
+- Localization and mechanism are evidence-backed;
+- Reproduction or alternative verification is adequate;
+- Every technical and management cause has an implemented action;
+- Effectiveness and adverse effects were evaluated;
+- Horizontal deployment and document changes are complete;
+- Reports, evidence identifiers, signatures, approvals, residual issues, and recommendations
+  are complete.
+
+Close and disband the team only after all actions are implemented and verified, lessons are
+deployed, and affected parties are told that zeroing is complete.
+
+If complete zeroing is not feasible for a flight test or in-orbit issue, document the reason,
+analyze all plausible root causes, implement comprehensive controls against them, identify
+residual risk, and obtain the required approval. Never label an unresolved hypothesis as a
+confirmed cause.
+
+## Supporting Methods and Related Skills
+
+Read [engineering methods](references/engineering-methods.md) when choosing troubleshooting,
+reproduction, measure-verification, controlled-experimentation, or workflow-control methods.
+These methods are advisory and cannot weaken a standard gate.
+
+- Use [NCR writing](../../documentation/ncr-writing/) to document a detected nonconformance
+  when the organization's quality system requires an NCR before zeroing.
+- Use [Is/Is-Not](../is-is-not-scoping/) to define the observed boundary.
+- Use [Fishbone](../fishbone-analysis/) to generate candidate causes.
+- Use separate [5-Why](../5why-root-cause/) chains for distinct causal paths.
+- Use [PFMEA](../../risk-analysis/pfmea-process/) or
+  [DFMEA](../../risk-analysis/dfmea-design/) to evaluate action risk and update prevention
+  controls, and update the [Control Plan](../../planning/control-plan/) when process controls
+  change.
+- Use [CAR](../../documentation/car-corrective-action/) when the organization requires a
+  separate corrective-action record for implementation and effectiveness follow-up.
+- Use [8D](../8d-problem-solving/) when a customer or sector requires the 8D format; do not
+  claim that an 8D automatically satisfies GB/T 29076—2021 without checking every zeroing gate.
+
+Framework handoff:
+
+`Detection / NCR → zeroing route decision → technical and/or management zeroing → corrective
+action → FMEA / Control Plan / controlled-document updates → evidence review → closure`
+
+## Validation Criteria
+
+Reject closure if any answer is “no”:
+
+1. Is the exact failure location proven to the lowest practicable unit?
+2. Does the mechanism explain the observations and all confirmed root causes?
+3. Was the mechanism reproduced or otherwise verified with justified evidence?
+4. Does each action map to a confirmed cause and have implementation evidence?
+5. Was action effectiveness verified over a relevant range and checked for adverse effects?
+6. Was the exposed population searched across product, process, and organization?
+7. Where management zeroing applies, are process, responsibility, actions, treatment, and
+   rules complete?
+8. Are evidence, controlled-document revisions, reviews, approvals, residual risks, and
+   stakeholder communications traceable?
+
+## Common Mistakes
+
+- Treating repair, rework, sorting, inspection, or emergency containment as root-cause action;
+- Confusing failure location with root cause or a plausible cause with a proven mechanism;
+- Repeating a test without new instrumentation, controlled variables, or a stated hypothesis;
+- Choosing only one convenient root cause when evidence supports multiple causes;
+- Using “operator error” or “supplier problem” as the end of analysis;
+- Punishing people by default instead of correcting the management system;
+- Declaring “no similar issue found” without defining the searched population and method;
+- Closing tasks in a workflow system and assuming the quality problem is therefore zeroed;
+- Changing “完善规章” into the weaker phrase “improve the mechanism” without controlled documents;
+- Adding a sixth normative technical-zeroing requirement; knowledge extraction belongs within
+  horizontal deployment and document institutionalization.
+
+## Output Content
+
+Produce, as applicable:
+
+1. Problem and impact statement;
+2. Emergency response and affected-population record;
+3. Team, plan, zeroing-route decision, and milestones;
+4. Technical zeroing report with five evidence gates;
+5. Management zeroing report with five evidence gates;
+6. Cause-to-action-to-evidence traceability matrix;
+7. Horizontal-deployment register;
+8. Residual-risk and unresolved-item register;
+9. Review checklist, approval decision, and closure statement.
+
+## Output Format
+
+At the start of each use, ask the user:
+
+> "How would you like to receive the output?
+> **A** — Structured Markdown (formatted tables and sections, ready to copy)
+> **B** — Plain tables (simplified structure for Excel or Word)
+> **C** — Narrative report (flowing text for a formal document or email)
+>
+> Default: A."
+
+Adapt all output sections to the chosen format. If the platform or session context already defines a format preference, skip this question.
+
+## Reference Files
+
+- [GB/T 29076—2021 method guide](references/gbt-29076-2021-method-guide.md)
+- [Engineering methods and research notes](references/engineering-methods.md)
+- [Technical and management zeroing report template](assets/zeroing-report-template.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-07-04 | @Crow12138 | Initial draft based on GB/T 29076—2021 |

--- a/platforms/chatgpt/knowledge/spc-control-charts.md
+++ b/platforms/chatgpt/knowledge/spc-control-charts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: spc-control-charts
 description: >-
   Statistical Process Control (SPC) — select the correct control chart, interpret out-of-control

--- a/platforms/chatgpt/knowledge/supplier-scar.md
+++ b/platforms/chatgpt/knowledge/supplier-scar.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: supplier-scar
 description: >-
   Supplier Corrective Action Request (SCAR) — escalate a supplier non-conformance to a formal

--- a/platforms/chatgpt/knowledge/vda-6-3-audit.md
+++ b/platforms/chatgpt/knowledge/vda-6-3-audit.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: vda-6-3-audit
 description: >-
   VDA 6.3 Process Audit — conduct or prepare for a process audit using the VDA 6.3 methodology,

--- a/platforms/claude-ai/knowledge/5why-root-cause.md
+++ b/platforms/claude-ai/knowledge/5why-root-cause.md
@@ -14,6 +14,12 @@ metadata:
   domain: quality-engineering
   subdomain: problem-solving
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: RBraga01
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015"
 ---
 
 # 5-Why Root Cause Analysis
@@ -175,3 +181,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 ## Reference files
 
 - [Chain validation guide](references/chain-validation.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @RBraga01 | Added dual-chain requirement (occurrence + escape), evidence status tracking |

--- a/platforms/claude-ai/knowledge/8d-problem-solving.md
+++ b/platforms/claude-ai/knowledge/8d-problem-solving.md
@@ -14,6 +14,12 @@ metadata:
   domain: quality-engineering
   subdomain: problem-solving
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: RBraga01
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015 / IATF 16949:2016"
 ---
 
 # 8D Problem Solving
@@ -264,3 +270,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 
 - [D0–D8 detailed guide](references/d0-d8-guide.md)
 - [8D report template](assets/8d-template.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @RBraga01 | Added Required Execution Checklist, D-level validation criteria, OEM gate rules |

--- a/platforms/claude-ai/knowledge/8d-report-writing.md
+++ b/platforms/claude-ai/knowledge/8d-report-writing.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iso-9001: "10.2"
   iatf-16949: "10.2.3"
   domain: quality-engineering
   subdomain: documentation
   industries: automotive,electronics
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015 / IATF 16949:2016"
 ---
 
 # 8D Customer Report Writing
@@ -253,3 +259,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 ## Reference files
 
 - [OEM-specific requirements](references/oem-formats.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @migmcc | Added OEM format requirements and customer submission checklists |

--- a/platforms/claude-ai/knowledge/8d-template.md
+++ b/platforms/claude-ai/knowledge/8d-template.md
@@ -1,3 +1,17 @@
+---
+name: 8d-template
+type: asset
+parent_skill: 8d-problem-solving
+author: RBraga01
+version: "1.0"
+status: approved
+created: "2026-06-01"
+last_updated: "2026-06-03"
+updated_by: RBraga01
+reviewed_by: RBraga01
+license: MIT
+---
+
 # 8D Report Template
 
 **8D Number:** ___________

--- a/platforms/claude-ai/knowledge/action-priority-ap.md
+++ b/platforms/claude-ai/knowledge/action-priority-ap.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iatf-16949: "8.3.3.3"
   aiag-reference: "AIAG-VDA FMEA Handbook 2019, Step 5, Table 5-3"
   domain: quality-engineering
   subdomain: risk-analysis
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "AIAG-VDA FMEA Handbook 2019"
 ---
 
 # Action Priority (AP) — AIAG-VDA 2019
@@ -31,7 +37,8 @@ Assign and audit Action Priority (AP) ratings correctly using the AIAG-VDA 2019 
 ☐ Confirm O is based on the Failure Cause with current prevention controls in place
 ☐ Confirm D is based on current detection controls for this Failure Mode
 ☐ All S, O, and D ratings are supported by data, field history, capability data, or documented engineering judgement — not guesses
-☐ Assign AP using the full AIAG-VDA AP table (see assets/ap-table.md) — not only the summary patterns in this skill
+☐ Assign AP using the full AP determination rules (see [ap-table.md](../pfmea-process/assets/ap-table.md)) — not only the summary patterns in this skill
+☐ For formal PPAP submissions, customer-facing FMEAs, or any disputed rating, confirm against your licensed AIAG-VDA FMEA Handbook — the rating criteria that make an S, O or D value defensible are in the handbook, not in this skill
 ☐ For every H-AP item: define a corrective action with owner and target date, or document a formal escalation rationale
 ☐ Reassess AP only after the corrective action is implemented and verified — not when only planned
 ☐ Verify Special Characteristics are rated S = 9 or 10
@@ -95,7 +102,7 @@ M-AP does not mean "no action needed." It means action is not mandatory, but the
 
 ## AP Assessment Workflow
 
-> This skill explains AP logic and decision patterns. Use the full AP table (assets/ap-table.md) for final rating assignment. Do not rely solely on the summary patterns below for disputed cases or formal PPAP submissions.
+> This skill explains AP logic and decision patterns. Use the full AP determination rules ([ap-table.md](../pfmea-process/assets/ap-table.md)) for final rating assignment. Do not rely solely on the summary patterns below for disputed cases or formal PPAP submissions — those require the rating criteria in your licensed AIAG-VDA FMEA Handbook.
 
 **Before assigning AP:** Do not assign AP unless S, O, and D are already justified based on the linked failure effect, failure cause, and current controls. AP is only as good as the ratings it is built on.
 
@@ -109,7 +116,7 @@ For each FC (Failure Cause) row in the PFMEA/DFMEA:
 
 3. Assign O (for this Failure Cause with current prevention controls)
 4. Assign D (for this Failure Mode with current detection controls)
-5. Look up AP in the full table (see assets/ap-table.md)
+5. Look up AP in the full table (see ../pfmea-process/assets/ap-table.md)
 ```
 
 **All S, O, and D ratings must be supported by test data, field history, capability data, or documented engineering judgement.**
@@ -206,3 +213,10 @@ At the start of each use, ask the user:
 > Default: A."
 
 Adapt all output sections to the chosen format. If the platform or session context already defines a format preference, skip this question.
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @migmcc | Polished AP classification logic, added OEM CSR requirements table |

--- a/platforms/claude-ai/knowledge/ap-table.md
+++ b/platforms/claude-ai/knowledge/ap-table.md
@@ -1,12 +1,42 @@
-# AIAG-VDA Action Priority (AP) Table
+---
+name: ap-table
+type: asset
+parent_skill: pfmea-process
+author: RBraga01
+version: "1.0"
+status: approved
+created: "2026-06-01"
+last_updated: "2026-06-03"
+updated_by: RBraga01
+reviewed_by: RBraga01
+license: MIT
+license-note: >-
+  MIT covers the original expression in this file. It does not extend to the
+  AIAG-VDA FMEA Handbook, which is a separately licensed third-party work.
+  See THIRD_PARTY_CONTENT.md.
+---
 
-Reference: AIAG-VDA FMEA Handbook 2019, Step 5, Table 5-3
+# Action Priority (AP) Determination Rules
 
-## How to read the table
+**What this file is.** An independent restatement of the Action Priority decision
+logic used in the AIAG-VDA FMEA methodology (2019 joint edition), expressed as
+banded rules. It is **not** a reproduction of the handbook's Action Priority
+table, and it does not replace it.
+
+**What this file is not.** The authoritative AP table enumerates every S/O/D
+combination and comes with the rating criteria tables that define what each S, O
+and D value means. Those criteria are what make a rating defensible in an audit,
+and they are not in this file. For formal PPAP submissions, customer-facing FMEA
+work, or any disputed rating, use your own licensed copy of the handbook.
+
+AIAG and VDA are trademarks of their respective owners. This project is not
+affiliated with, endorsed by, or certified by either organisation.
+
+## How to apply the rules
 
 1. Find the Severity (S) row
-2. Find the Occurrence (O) column range
-3. Find the Detection (D) range
+2. Find the Occurrence (O) band
+3. Find the Detection (D) band
 4. Read the Action Priority: **H** (High), **M** (Medium), **L** (Low)
 
 ## Absolute rules (override the table)
@@ -16,7 +46,7 @@ Reference: AIAG-VDA FMEA Handbook 2019, Step 5, Table 5-3
 | S = 9 or 10 | Always **H** — regardless of O and D |
 | S = 8, O = 4–10 | **H** if D ≥ 5; **M** if D ≤ 4 |
 
-## AP Table (AIAG-VDA 2019 summary)
+## AP decision rules (banded)
 
 | S | O | D | AP |
 |---|---|---|----|

--- a/platforms/claude-ai/knowledge/apqp.md
+++ b/platforms/claude-ai/knowledge/apqp.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: apqp
 description: >-
   Advanced Product Quality Planning (APQP) — plan and track a new product launch through all 5 phases,

--- a/platforms/claude-ai/knowledge/car-corrective-action.md
+++ b/platforms/claude-ai/knowledge/car-corrective-action.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iso-9001: "10.2"
   iatf-16949: "10.2.3"
   domain: quality-engineering
   subdomain: documentation
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-04"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015"
 ---
 
 # Corrective Action Request (CAR) Writing
@@ -26,7 +32,7 @@ A CAR is written in response to:
 - An internal or external audit finding (Major or Minor non-conformance)
 - A recurring non-conformance requiring systemic correction
 
-The CAR is the documented evidence that the problem was analysed, corrected, and prevented from recurring. ISO 9001 §10.2.1 requires documented information of the actions taken and their results.
+The CAR is the documented evidence that the problem was analysed, corrected, and prevented from recurring. ISO 9001 §10.2.1 requires documented information of the actions taken and their results. For IATF 16949 audit Major NCs, CARs must typically be closed within 90 days; check the applicable CSR for customer-specific closure deadlines.
 
 ## Key distinction from NCR
 
@@ -39,6 +45,8 @@ The CAR is the documented evidence that the problem was analysed, corrected, and
 
 A CAR references the NCR but extends it into corrective action territory.
 
+---
+
 ## CAR structure
 
 ### 1. Header
@@ -50,11 +58,12 @@ A CAR references the NCR but extends it into corrective action territory.
 | Date opened | |
 | Owner | Responsible person (name, not function) |
 | Target closure date | |
+| Closure authority | Named person with authority to close this CAR (quality manager or equivalent) |
 | Actual closure date | (filled on closure) |
 
 ### 2. Problem summary
 
-One or two sentences summarising the NCR or finding. Objective, factual.
+One or two sentences summarising the NCR or finding. Objective, factual. Must match the NCR description exactly — no new interpretation.
 
 Example:
 > "47 of 200 connector units in lot 2026-05-12-A had pin insertion depth 0.6–1.5 mm below lower specification limit (5.0 ± 0.3 mm). Detected at incoming inspection (NCR-2026-0047)."
@@ -88,7 +97,13 @@ Why: Not detected at our outgoing inspection → Why: no depth measurement in ou
 inspection plan → Root cause: Control Plan does not include pin depth at outgoing.
 ```
 
-**Validation:** state how the root cause was confirmed (reproduction test, data correlation, physical evidence).
+**Validation:** state how the root cause was confirmed. Acceptable validation methods:
+- Reproduction test (demonstrated that removing/restoring the root cause produces/prevents the defect)
+- Data correlation (statistical relationship between root cause variable and defect occurrence)
+- Physical evidence (inspection of the failed part or process reveals the causal mechanism)
+- Direct record review (confirms the absence of the required control)
+
+A root cause supported only by team opinion (not validated by evidence) cannot be used as the basis for CAR closure.
 
 ### 5. Corrective actions
 
@@ -127,17 +142,26 @@ This is where most CARs fail. The action is implemented, but nobody checks wheth
 3. **Volume/duration:** what sample size or time period constitutes sufficient evidence?
 4. **Target:** what result confirms the action was effective?
 
-**Typical VOE approach for a process change:**
-- Produce a minimum of [300 units / 30 shifts / 3 months] with the new process
-- Zero recurrence of the original defect mode during this period
-- Confirm with inspection data
+**VOE minimum volume guidance:**
+- For a defect with known base rate: the VOE sample must be large enough to observe at least one recurrence if the action had failed. Example: if baseline defect rate was 5%, a zero-defect sample of 60 units gives 95% confidence the rate is now below 5%.
+- For process parameter changes: minimum 30 consecutive production cycles under the new conditions, or as defined by the Control Plan sampling frequency × 3 periods.
+- For detection control improvements: minimum one full inspection cycle of the affected product family with zero escapes.
+- Minimum in all cases: state the volume used and the basis for choosing it. "Zero defects in 10 units" is not a valid VOE for a high-volume process.
 
 **VOE result:**
 - Record the actual results after the monitoring period
 - State: Effective / Not effective
 - If not effective: return to root cause analysis and repeat
 
-### 8. Systemic prevention and horizontal deployment
+### 8. AP revision (AIAG-VDA, if applicable)
+
+If the non-conformance relates to a PFMEA failure mode with an Action Priority (AP) rating:
+
+- After verified implementation of the corrective action, the PFMEA must be updated with a revised S, O, and/or D rating
+- The revised AP (AP-revised) must reflect the improvement — it must be lower than the original AP or documented with justification if unchanged
+- Revised AP is recorded only after VOE is complete, not at the time of action planning
+
+### 9. Systemic prevention and horizontal deployment
 
 Ask: could this same root cause exist in similar parts, processes, or product families?
 
@@ -146,7 +170,7 @@ If yes:
 - Document the actions taken to extend the corrective action
 - Evidence that horizontal deployment is complete
 
-### 9. Lessons learned
+### 10. Lessons learned
 
 One or two sentences capturing the key learning for future reference:
 
@@ -158,22 +182,31 @@ File in the lessons learned register and reference in PFMEA update.
 
 ## Closure criteria
 
-A CAR may only be closed when ALL of the following are true:
-- [ ] Root causes of occurrence and escape are documented with evidence
-- [ ] Corrective actions are implemented and documented
-- [ ] VOE is complete and confirms effectiveness
-- [ ] PFMEA is updated (revised failure mode entry)
+A CAR may only be closed when ALL of the following are true, and the closure authority (named in the header) has signed off:
+
+- [ ] Root causes of occurrence and escape are documented with validation evidence
+- [ ] Corrective actions are implemented and documented with revision numbers and approval dates
+- [ ] VOE is complete with documented sample volume and confirms effectiveness
+- [ ] PFMEA is updated (revised failure mode entry, revised AP if applicable)
 - [ ] Control Plan is updated (if detection control changed)
 - [ ] Work Instructions are updated (if process control changed)
 - [ ] Horizontal deployment is documented
-- [ ] Customer notified of closure (if CAR was triggered by customer complaint)
+- [ ] Customer notified of closure (if CAR was triggered by customer complaint or CSR-required notification)
+- [ ] Closure authority sign-off obtained
+
+---
 
 ## Common mistakes
 
 - **"Retrain operators"** as a corrective action for human error — this is never sufficient alone; the system that allowed the error must be changed
 - **Closing without VOE** — the most common reason for recurring non-conformances
+- **VOE on insufficient sample** — "zero defects in 5 units" is not effectiveness verification; define the minimum volume before collecting data
 - **Implementing actions without updating PFMEA and Control Plan** — next audit will find the gap
 - **Generic actions** — "review procedures" → not specific; must state which procedure, revised to say what, by whom, by when
+- **Closing without named authority sign-off** — any team member closing a CAR without defined authority is a governance gap
+- **Missing AP revision** — when PCA addresses a PFMEA failure mode, the revised AP must be recorded after VOE
+
+---
 
 ## Output Format
 
@@ -187,3 +220,10 @@ At the start of each use, ask the user:
 > Default: A."
 
 Adapt all output sections to the chosen format. If the platform or session context already defines a format preference, skip this question.
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-04 | @migmcc | Expanded CAR linkage to D5-D6, added effectiveness verification requirements |

--- a/platforms/claude-ai/knowledge/control-plan-builder.md
+++ b/platforms/claude-ai/knowledge/control-plan-builder.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: control-plan-builder
 description: >-
   Interactive Control Plan builder — takes PFMEA failure modes and process flow steps as input and

--- a/platforms/claude-ai/knowledge/control-plan.md
+++ b/platforms/claude-ai/knowledge/control-plan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: control-plan
 description: >-
   Control Plan — build, review, or audit a Prototype, Pre-launch, or Production Control Plan linked

--- a/platforms/claude-ai/knowledge/d0-d8-guide.md
+++ b/platforms/claude-ai/knowledge/d0-d8-guide.md
@@ -1,3 +1,17 @@
+---
+name: d0-d8-guide
+type: reference
+parent_skill: 8d-problem-solving
+author: RBraga01
+version: "1.0"
+status: approved
+created: "2026-06-01"
+last_updated: "2026-06-03"
+updated_by: RBraga01
+reviewed_by: RBraga01
+license: MIT
+---
+
 # D0–D8 Reference Guide
 
 Complete reference for the Eight Disciplines (8D) problem-solving methodology.
@@ -206,7 +220,7 @@ Stop the non-conforming product from reaching the customer while D4–D5 are in 
 | Stellantis | 8D (MAQMSR) | Recommended | SQS Portal |
 | GM | Global 8D | Recommended | Covisint |
 
-See [oem-formats](../../documentation/8d-report-writing/references/oem-formats.md) for full detail.
+See [oem-formats](../../../documentation/8d-report-writing/references/oem-formats.md) for full detail.
 
 ---
 

--- a/platforms/claude-ai/knowledge/dfmea-design.md
+++ b/platforms/claude-ai/knowledge/dfmea-design.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: dfmea-design
 description: >-
   Build a design risk analysis, DFMEA worksheet, or interface analysis using the AIAG-VDA

--- a/platforms/claude-ai/knowledge/dmaic.md
+++ b/platforms/claude-ai/knowledge/dmaic.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: dmaic
 description: >-
   DMAIC (Define-Measure-Analyze-Improve-Control) — Six Sigma structured problem-solving for

--- a/platforms/claude-ai/knowledge/dvp-test-plan.md
+++ b/platforms/claude-ai/knowledge/dvp-test-plan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: dvp-test-plan
 description: >-
   Design Verification Plan and Report (DVP&R) — build or review a test plan that links each DFMEA

--- a/platforms/claude-ai/knowledge/fishbone-analysis.md
+++ b/platforms/claude-ai/knowledge/fishbone-analysis.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iso-9001: "10.2"
   iatf-16949: "10.2.3"
   domain: quality-engineering
   subdomain: problem-solving
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-04"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015"
 ---
 
 # Fishbone (Ishikawa) Analysis
@@ -30,9 +36,22 @@ Typical use: 8D D4 brainstorming session, CAPA root cause investigation, initial
 - Cross-functional team (quality, production, engineering at minimum)
 - Access to the process, machine, or product where defect occurred
 
+## Required Fishbone Checklist
+
+☐ Problem statement defined and agreed before starting — no cause language in the problem statement
+☐ All 6M categories addressed — at least one entry per M, or documented justification if a category is not applicable
+☐ Brainstorming completed before any evaluation or elimination — do not evaluate while generating
+☐ Every cause classified as Confirmed, Probable, or Unlikely using objective evidence — not opinion alone
+☐ Confirmed = supported by data or physical evidence; Probable = logical, consistent with Is/Is-Not, not yet confirmed; Unlikely = contradicted by data
+☐ Confirmed and Probable causes cross-checked against existing PFMEA failure cause entries before proceeding to 5-Why
+☐ Each Confirmed or Probable cause carries forward to its own 5-Why chain
+☐ After root cause confirmed: horizontal deployment check — could the same cause exist in similar parts, processes, or product families?
+
+---
+
 ## The 6M Framework
 
-The six main "bones" of the fish:
+The six main "bones" of the fish. **All six must be addressed.** If a category genuinely does not apply, document: "No causes identified in this category after structured team review — not applicable because [reason]."
 
 ### 1. Man (Human Factors)
 
@@ -91,6 +110,8 @@ Questions to ask:
 - Are there seasonal patterns?
 - Does the cleanroom or ESD environment meet requirements?
 
+---
+
 ## Workflow
 
 ### Step 1 — Draw the diagram
@@ -101,24 +122,35 @@ Write the problem (effect) at the head (right side). Draw the spine. Add six mai
 
 For each M category: "What in [M] could cause [the problem]?"
 
-Capture all ideas without judgment — quantity first, evaluation second.
+Capture all ideas without judgment — quantity first, evaluation second. **Do not evaluate or discard during brainstorming.** Allocate 30–60 minutes minimum. Time pressure is the most common reason causes are missed.
 
 Add each cause as a sub-bone to the relevant M category. Sub-bones can branch further (cause of a cause).
 
 ### Step 3 — Evaluate and prioritise
 
 Mark each cause as:
-- **Confirmed** (supported by data or direct evidence)
-- **Probable** (logical but not yet confirmed)
-- **Unlikely** (logical argument against it)
+- **Confirmed** (supported by data or direct physical evidence — not opinion)
+- **Probable** (logical, consistent with the Is/Is-Not pattern, but not yet confirmed by data)
+- **Unlikely** (contradicted by data or the Is/Is-Not pattern)
 
-Discard unlikely causes. Investigate confirmed and probable causes.
+Discard Unlikely causes. Investigate Confirmed and Probable causes. A cause cannot be classified as Confirmed without objective evidence (measurement data, physical demonstration, reproduction test, or direct record review).
 
-### Step 4 — Connect to 5-Why
+### Step 4 — PFMEA cross-check
 
-For each confirmed or probable cause, run a [5-Why chain](../5why-root-cause/) to reach the systemic root cause.
+Before proceeding to 5-Why, cross-check Confirmed and Probable causes against the existing PFMEA:
+
+- Is this failure cause already documented in the PFMEA? If yes, was its detection or prevention control supposed to prevent this defect?
+- If the PFMEA did not capture this cause, flag it — the PFMEA must be updated after the root cause is confirmed.
+
+### Step 5 — Connect to 5-Why
+
+For each Confirmed or Probable cause, run a [5-Why chain](../5why-root-cause/) to reach the systemic root cause.
 
 The fishbone identifies candidate causes. The 5-Why validates and deepens them.
+
+After root cause is confirmed: assess whether the same cause could exist in similar parts, processes, or product families. Document horizontal deployment actions if applicable.
+
+---
 
 ## Output format
 
@@ -133,12 +165,20 @@ Document the fishbone as a table (easier to include in reports than a diagram):
 | Measurement | Gauge repeatability | GR&R = 8% — acceptable | No |
 | Environment | Temperature | Controlled at 22°C ± 2°C — stable | No |
 
+All 6M categories must appear in the table. If a category has no entries after structured brainstorming, document: "No causes identified in this category after structured team review."
+
+---
+
 ## Common mistakes
 
 - **Brainstorming under time pressure** — causes are missed; allocate 30–60 minutes minimum
 - **Stopping at first-level causes** — "machine not calibrated" is a cause, but add sub-bone: why was it not calibrated?
-- **Not using data to confirm/discard** — every cause must be validated, not just listed
+- **Not using data to confirm/discard** — every cause must be validated against objective evidence, not just listed
 - **Using fishbone as the root cause** — fishbone finds candidate causes; 5-Why finds root cause
+- **Skipping categories** — if a category is left blank without justification, the analysis is incomplete and may miss the real cause
+- **Classifying causes as Confirmed based on team opinion** — Confirmed requires evidence; without it, classify as Probable and plan verification
+
+---
 
 ## Output Format
 
@@ -152,3 +192,10 @@ At the start of each use, ask the user:
 > Default: A."
 
 Adapt all output sections to the chosen format. If the platform or session context already defines a format preference, skip this question.
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-04 | @migmcc | Polished 6M categories, added validation criteria and 5-Why integration |

--- a/platforms/claude-ai/knowledge/iatf-16949-audit.md
+++ b/platforms/claude-ai/knowledge/iatf-16949-audit.md
@@ -9,11 +9,17 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iatf-16949: "9.2.2"
   domain: quality-engineering
   subdomain: audit
   industries: automotive,electronics
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "IATF 16949:2016"
 ---
 
 # IATF 16949:2016 Internal Audit — Supplemental Requirements
@@ -361,3 +367,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 ## Reference files
 
 - [IATF supplemental requirements checklist](references/supplemental-requirements.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @migmcc | Added supplemental requirements reference and CSR audit coverage |

--- a/platforms/claude-ai/knowledge/is-is-not-scoping.md
+++ b/platforms/claude-ai/knowledge/is-is-not-scoping.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iso-9001: "10.2"
   iatf-16949: "10.2.3"
   domain: quality-engineering
   subdomain: problem-solving
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-04"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015"
 ---
 
 # Is/Is-Not Problem Scoping
@@ -23,6 +29,24 @@ metadata:
 Use Is/Is-Not at the start of any quality investigation to precisely define what the problem IS and what it IS NOT. This scoping prevents wasted investigation effort and immediately eliminates hypotheses that cannot explain the observed IS/IS-NOT pattern.
 
 Most effective in 8D D2 (problem description), CAPA scoping, and any situation where the defect is intermittent, batch-specific, or location-specific.
+
+## Critical rule — facts only
+
+**The IS column contains only documented, measured facts.** Hypotheses, assumptions, and opinions belong in the hypothesis list, not in the matrix. If a cell contains an assumption rather than a fact, the entire analysis is compromised.
+
+If data is not yet available: mark the cell as "Unknown — to be investigated" and identify what investigation is needed before proceeding.
+
+## Required Is/Is-Not Checklist
+
+☐ All five dimensions completed — What, Which, Where, When, How many — or marked "Unknown — to be investigated"
+☐ IS column contains only documented facts and measured values — no assumptions, no hypotheses
+☐ IS NOT column completed for each dimension — this is where hypotheses get eliminated; do not leave blank
+☐ Vague IS statements converted to specific facts with numbers (batch, quantity, percentage)
+☐ At least three hypotheses generated and tested against the full matrix
+☐ Eliminated hypotheses documented with the specific IS/IS-NOT entry that contradicts them
+☐ Is/Is-Not output referenced in the NCR problem description and carried forward to Fishbone or 5-Why
+
+---
 
 ## The Is/Is-Not Matrix
 
@@ -70,9 +94,11 @@ Example: "IS: First observed 2026-05-12, all shifts. IS NOT: Before 2026-05-10."
 |----|--------|
 | Defect rate (parts per million, percentage) | What rate is NOT observed |
 | Quantity affected | Quantity not affected |
-| Trend (increasing, stable, decreasing) | |
+| Trend (increasing, stable, decreasing) | No trend in unaffected population |
 
 Example: "IS: 23.5% of parts in affected batches (47/200). IS NOT: Any defects in batches before 2026-05-10 (0/500 inspected)."
+
+---
 
 ## Using the matrix to eliminate hypotheses
 
@@ -88,31 +114,42 @@ Once the matrix is complete, generate hypotheses and test each against the IS/IS
 - IS NOT: Not found at our outgoing inspection → **contradicts** (if we measure 100%, our gauge would catch it)
 → Hypothesis eliminated
 
-Any hypothesis that cannot explain ALL items in the IS and IS-NOT columns is eliminated or requires modification.
+Any hypothesis that cannot explain ALL items in the IS and IS-NOT columns is eliminated or requires modification. Document the specific contradiction for each eliminated hypothesis.
+
+---
 
 ## Workflow
 
 1. Gather data: inspection records, production records, customer complaint details
-2. Fill in the matrix — only include facts, not hypotheses
+2. Fill in the matrix — only include facts, not hypotheses; mark gaps as "Unknown — to be investigated"
 3. Identify the "clue" — what distinctive pattern appears (specific batch, specific location, specific time)?
-4. List candidate hypotheses
+4. List candidate hypotheses (minimum three)
 5. Test each hypothesis against the full matrix
-6. Eliminate those that contradict the data
+6. Eliminate those that contradict the data — document the contradiction
 7. Carry forward surviving hypotheses into Fishbone or 5-Why
+8. Reference the Is/Is-Not matrix in the NCR problem description — the IS "What" entry is the basis for the NCR non-conformance description
+
+---
 
 ## Output format
 
 A complete Is/Is-Not matrix (table format) with:
-- All five dimensions completed with specific facts
-- Surviving hypotheses listed with explanation of why they fit the matrix
-- Eliminated hypotheses listed with the specific contradiction
+- All five dimensions completed with specific facts (or "Unknown — to be investigated")
+- Surviving hypotheses listed with explanation of why they fit the full matrix
+- Eliminated hypotheses listed with the specific contradiction that rules each one out
+
+---
 
 ## Common mistakes
 
-- **Listing assumptions as IS** — only documented, measured facts go in the matrix
-- **Leaving cells empty** — if you don't know, mark "unknown — to be investigated"
+- **Listing assumptions as IS** — only documented, measured facts go in the matrix; assumptions generate false hypotheses
+- **Leaving cells empty** — if you don't know, mark "Unknown — to be investigated"; empty cells mean the analysis is incomplete
 - **Not using IS NOT** — the IS NOT column is where hypotheses get eliminated; skipping it wastes investigation time
-- **Vague IS statements** — "some parts are bad" → must be: "23.5% of batch 2026-05-12 are non-conforming on dimension X"
+- **Vague IS statements** — "some parts are bad" → must be: "23.5% of batch 2026-05-12 are non-conforming on dimension X (47/200 units measured)"
+- **Testing only one or two hypotheses** — generate at least three before starting elimination; premature narrowing misses the real cause
+- **Not linking output to NCR** — the Is/Is-Not "What IS" entry must match the NCR problem description exactly
+
+---
 
 ## Output Format
 
@@ -126,3 +163,10 @@ At the start of each use, ask the user:
 > Default: A."
 
 Adapt all output sections to the chosen format. If the platform or session context already defines a format preference, skip this question.
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-04 | @migmcc | Expanded Is/Is-Not table criteria and D2 integration guidance |

--- a/platforms/claude-ai/knowledge/iso-9001-internal-audit.md
+++ b/platforms/claude-ai/knowledge/iso-9001-internal-audit.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iso-9001: "9.2"
   iatf-16949: "9.2.2"
   domain: quality-engineering
   subdomain: audit
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015"
 ---
 
 # ISO 9001:2015 Internal Audit
@@ -414,3 +420,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 ## Reference files
 
 - [Clause-by-clause question bank](references/clause-questions.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @migmcc | Expanded clause-by-clause question bank and evidence anchors |

--- a/platforms/claude-ai/knowledge/msa-gauge-rr.md
+++ b/platforms/claude-ai/knowledge/msa-gauge-rr.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: msa-gauge-rr
 description: >-
   Measurement System Analysis (MSA) and Gauge Repeatability & Reproducibility (Gauge R&R) — plan,

--- a/platforms/claude-ai/knowledge/ncr-writing.md
+++ b/platforms/claude-ai/knowledge/ncr-writing.md
@@ -8,12 +8,18 @@ description: >-
 license: MIT
 metadata:
   author: RBraga01
-  version: "1.0"
+  version: "1.1"
   iso-9001: "8.7"
   iatf-16949: "8.7.1"
   domain: quality-engineering
   subdomain: documentation
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: migmcc
+  reviewed_by: RBraga01
+  standard_edition: "ISO 9001:2015"
 ---
 
 # Non-Conformance Report (NCR) Writing
@@ -202,3 +208,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 ## Reference files
 
 - [NCR template](assets/ncr-template.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @migmcc | Expanded severity classification criteria and disposition guidance |

--- a/platforms/claude-ai/knowledge/oem-formats.md
+++ b/platforms/claude-ai/knowledge/oem-formats.md
@@ -1,3 +1,17 @@
+---
+name: oem-formats
+type: reference
+parent_skill: 8d-report-writing
+author: RBraga01
+version: "1.0"
+status: approved
+created: "2026-06-01"
+last_updated: "2026-06-03"
+updated_by: migmcc
+reviewed_by: RBraga01
+license: MIT
+---
+
 # OEM 8D Report Formats — Reference
 
 Differences between OEM-specific 8D submission formats.

--- a/platforms/claude-ai/knowledge/oem-requirements.md
+++ b/platforms/claude-ai/knowledge/oem-requirements.md
@@ -1,3 +1,17 @@
+---
+name: oem-requirements
+type: reference
+parent_skill: action-priority-ap
+author: RBraga01
+version: "1.0"
+status: approved
+created: "2026-06-01"
+last_updated: "2026-06-03"
+updated_by: migmcc
+reviewed_by: RBraga01
+license: MIT
+---
+
 # OEM Action Priority Requirements — Reference
 
 OEM-specific requirements for Action Priority (AP) in PFMEA and DFMEA.

--- a/platforms/claude-ai/knowledge/pdca-improvement.md
+++ b/platforms/claude-ai/knowledge/pdca-improvement.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: pdca-improvement
 description: >-
   Run a PDCA cycle, Plan Do Check Act improvement cycle, or structured improvement project.

--- a/platforms/claude-ai/knowledge/pfmea-process.md
+++ b/platforms/claude-ai/knowledge/pfmea-process.md
@@ -16,6 +16,12 @@ metadata:
   domain: quality-engineering
   subdomain: risk-analysis
   industries: automotive,electronics,aerospace,medical,general
+  status: approved
+  created: "2026-06-01"
+  last_updated: "2026-06-03"
+  updated_by: RBraga01
+  reviewed_by: RBraga01
+  standard_edition: "AIAG-VDA FMEA Handbook 2019"
 ---
 
 # Process FMEA (PFMEA) — AIAG-VDA 2019
@@ -262,3 +268,10 @@ Adapt all output sections to the chosen format. If the platform or session conte
 
 - [AIAG-VDA 2019 step-by-step guide](references/aiag-vda-2019.md)
 - [Action Priority table](assets/ap-table.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-06-01 | @RBraga01 | Initial release |
+| 1.1 | 2026-06-03 | @RBraga01 | Expanded 7-step workflow with AP gate requirements and PPAP integration |

--- a/platforms/claude-ai/knowledge/ppap-checker.md
+++ b/platforms/claude-ai/knowledge/ppap-checker.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: ppap-checker
 description: >-
   Interactive PPAP completeness checker — walks through all 18 PPAP elements for a given submission

--- a/platforms/claude-ai/knowledge/ppap.md
+++ b/platforms/claude-ai/knowledge/ppap.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: ppap
 description: >-
   Production Part Approval Process (PPAP) — verify PPAP submission level, audit all 18 elements,

--- a/platforms/claude-ai/knowledge/quality-problem-zeroing.md
+++ b/platforms/claude-ai/knowledge/quality-problem-zeroing.md
@@ -1,0 +1,376 @@
+---
+name: quality-problem-zeroing
+description: >-
+  Run quality problem zeroing, perform 双归零 (double-five zeroing), write a
+  technical zeroing report, write a management zeroing report, or close an
+  aerospace quality problem under GB/T 29076—2021. Covers problem reporting,
+  emergency response, team formation, technical zeroing (定位准确、机理清楚、问题复现、
+  措施有效、举一反三), management zeroing (过程清楚、责任明确、措施落实、严肃处理、
+  完善规章), evidence gates, review, and closure. Use for aerospace or complex
+  equipment failures, defects, accidents, repeated problems, human-responsibility
+  problems, and issues requiring a formal closed-loop investigation.
+license: MIT
+metadata:
+  author: Crow12138
+  version: "1.0"
+  iso-9001: "10.2 (supporting)"
+  gbt-29076: "2021"
+  domain: quality-engineering
+  subdomain: problem-solving
+  industries: aerospace,defense,aviation,complex-equipment,manufacturing
+  status: approved
+  created: "2026-07-04"
+  last_updated: "2026-07-04"
+  updated_by: Crow12138
+  reviewed_by: RBraga01
+  standard_edition: "GB/T 29076—2021"
+---
+
+# Quality Problem Zeroing
+
+## Goal
+
+Close a quality problem with objective evidence that:
+
+1. Locates and explains the technical failure;
+2. Removes every confirmed root cause and verifies the result;
+3. Identifies and repairs management weaknesses where required;
+4. Extends the learning to other exposed products, processes, and organizations; and
+5. Leaves no action, evidence, approval, or known residual risk hidden at closure.
+
+GB/T 29076—2021 is the controlling source for scope, sequence, terminology, and closure.
+Treat other methods and publications as supporting guidance only. Read the
+[standard method guide](references/gbt-29076-2021-method-guide.md) whenever a
+formal scope decision, report, or closure review is required.
+
+## When to Use
+
+Use this skill for an aerospace or complex-equipment quality problem that requires formal
+technical zeroing, management zeroing, double-five zeroing, an Annex A-aligned report, or a
+closure review. It is especially relevant to failures, defects, accidents, batch problems,
+repeated problems, field or delivered-product issues, human-responsibility problems, and
+problems caused by missing or inadequate rules.
+
+Use a narrower root-cause skill when the user only needs one analysis tool. Use 8D instead
+when the customer or sector mandates an 8D response, then cross-check whether the same event
+also requires GB/T 29076—2021 zeroing.
+
+## Required Execution Checklist
+
+- [ ] Record the product, problem phenomenon, operating state, time, location, environment, detector, and affected parties.
+- [ ] Protect the scene, product state, records, data, and physical evidence when safe to do so.
+- [ ] Assess safety, property, mission, delivered-product, and escalation risk immediately.
+- [ ] Identify, segregate, stop, recall, or inspect suspect product as required.
+- [ ] Form a cross-functional team with a named leader, authority, resources, and stakeholder representation.
+- [ ] Decide and document whether technical zeroing, management zeroing, or both apply.
+- [ ] Start technical zeroing first when both apply; never substitute it for management zeroing.
+- [ ] Build an evidence-backed technical causal chain from the lowest failed unit to the observed effect.
+- [ ] Identify all root causes; keep unproven explanations labelled as hypotheses.
+- [ ] Reproduce or otherwise verify the problem mechanism using an approved method.
+- [ ] Implement correction and root-cause corrective actions with owners and dates.
+- [ ] Verify effectiveness, sufficiency, and adverse effects before ending emergency controls.
+- [ ] Complete horizontal deployment across relevant products, processes, and organizations.
+- [ ] Reconstruct the management process and assign responsibility from duties and evidence.
+- [ ] Implement management actions and embed them in controlled rules, standards, or procedures.
+- [ ] Complete the required report, evidence list, signatures, and independent review.
+- [ ] Close only after all actions are complete, effectiveness is verified, and residual issues are explicit.
+
+## Workflow
+
+### 1. Report and preserve the problem
+
+Create the initial problem record before analysis changes the evidence. Capture:
+
+- Product name, identifier, batch, configuration, development or service stage, and responsible organizations;
+- Exact phenomenon, expected requirement, actual result, operating state, sequence, time, location, and environment;
+- Who detected the problem and how it was detected;
+- Available logs, measurements, photographs, samples, remains, test equipment state, and operator records;
+- Actual and potential effect on safety, mission, customer, schedule, cost, performance, and delivered product.
+
+Do not dismantle, clean, power-cycle, overwrite logs, swap parts, or repeat a destructive
+test until the evidence impact is assessed and the action is authorized.
+
+### 2. Apply emergency response
+
+When harm may continue or worsen:
+
+1. Identify and isolate suspect product;
+2. Stop work, delivery, use, or recall product where justified;
+3. Check related stock and the potentially affected population;
+4. Apply a temporary control against the apparent cause;
+5. Assess downstream and delivered-product risk;
+6. Confirm severity and notify affected internal and external parties.
+
+Keep emergency response separate from permanent corrective action. Remove it only after a
+more effective root-cause action is implemented and verified.
+
+### 3. Form and govern the team
+
+Include functions that own or understand the affected design, process, test, production,
+quality, supplier, use, and customer interfaces. Name:
+
+- The team leader and decision authority;
+- Each member's responsibility;
+- Required resources, constraints, milestones, communication cadence, and escalation route;
+- Customer, supplier, or other stakeholder representatives where affected.
+
+The quality function controls the plan, conformity check, review, action tracking, and
+retention of evidence. The responsible organization performs the investigation.
+
+### 4. Decide the zeroing route
+
+Apply **technical zeroing** when technical causes or consequences fall within the standard's
+scope, including significant design, production, test, field, delivered-product, batch,
+repeat, cost, schedule, performance, effectiveness, or system-application issues.
+
+Apply **management zeroing** to:
+
+- Repeated quality problems;
+- Human-responsibility problems such as knowingly disregarding a rule or violating an operation;
+- Problems caused by missing or inadequate rules;
+- Problems designated for management zeroing by the authorized management system.
+
+If both scopes apply, perform both and begin with technical zeroing. Record the route,
+severity level, responsible organization, target dates, and rationale. Do not assume every
+technical issue automatically requires punishment or management zeroing.
+
+### 5. Perform technical zeroing
+
+#### 5.1 Locate exactly — 定位准确
+
+Determine the exact process, product, assembly, component, part, electronic component,
+software element, interface, test equipment, or operation where the problem originates.
+Reach the lowest failed unit supported by evidence and state its abnormal condition.
+
+Check whether the source is the product, support equipment, test method, environment, or
+operation. Use controlled substitution only when it preserves evidence and its result is
+not mistaken for proof of mechanism.
+
+**Gate:** The location and affected boundary are specific, evidence-backed, communicated,
+and accepted by relevant parties. “The system failed” or “the supplier part was bad” does
+not pass.
+
+#### 5.2 Explain the mechanism — 机理清楚
+
+Build the causal chain from abnormal factor to final phenomenon. Identify all root causes
+and explain the physical, chemical, electrical, software, human-system, or process mechanism.
+Analyze the problem from three views:
+
+- **Product:** design, material, component, interface, software, equipment, and environment;
+- **Process:** requirements, design, procurement, production, inspection, test, change,
+  delivery, use, maintenance, and rework;
+- **Organization:** responsibility, competence, communication, resources, oversight, and rules.
+
+Use evidence to eliminate alternatives. Suitable tools include engineering analysis, failure
+analysis, statistics, FTA, FMEA, Fishbone, 5-Why, process analysis, DOE, and comparison.
+
+**Gate:** Every claimed root cause has objective support, alternative explanations have a
+documented disposition, and the causal chain explains all material observations.
+
+#### 5.3 Reproduce or verify — 问题复现
+
+Prepare and approve a verification plan defining:
+
+- Hypothesis and expected phenomenon;
+- Test article and controlled configuration;
+- Variables, realistic conditions, instrumentation, data to collect, and acceptance criteria;
+- Safety limits, stop criteria, responsibilities, and required approvals.
+
+Execute the plan, preserve raw records, analyze results, and obtain stakeholder agreement.
+Prefer a controlled, mechanism-driven reproduction over an uncontrolled repeat.
+
+For obvious one-off damage, destructive modes, or conditions that cannot be reproduced,
+document why a reproduction test is inappropriate and use theory, analysis, simulation,
+inspection, or an equivalent verification method. Do not convert “not reproduced” into
+“no problem.”
+
+**Gate:** The result confirms or rejects the location and mechanism. A failed confirmation
+returns the investigation to localization or mechanism analysis.
+
+#### 5.4 Prove effective measures — 措施有效
+
+Separate:
+
+- **Correction:** removes the detected problem from affected product;
+- **Corrective action:** removes each root cause to prevent recurrence;
+- **Preventive or deployment action:** protects similar products not yet affected.
+
+For every root cause, define a specific, measurable, executable, and verifiable action with
+an owner, due date, required resources, affected configuration, and verification plan.
+Evaluate whether each action may create a new or worse risk.
+
+Implement approved actions in controlled design, process, test, software, training, or
+standard documents. Compare post-action results with the original problem evidence.
+
+**Gate:** Evidence proves the actions are effective and sufficiently cover the operating
+range without unacceptable adverse effects. If not, return to mechanism analysis.
+
+#### 5.5 Extend the learning — 举一反三
+
+Search for the same or similar mechanism across:
+
+- The affected unit, batch, produced items, work in progress, and not-yet-produced items;
+- Related parts, interfaces, software, equipment, processes, suppliers, and product families;
+- Other programs, departments, and organizations exposed to the same cause.
+
+State the search population, method, findings, decisions, actions, owners, and evidence.
+Issue lessons learned or alerts through the quality function. Embed approved learning in
+design rules, process instructions, test requirements, training, databases, and tools.
+
+**Gate:** Horizontal deployment is based on mechanism and exposure, not merely on the same
+part number, and every finding has a disposition.
+
+### 6. Perform management zeroing
+
+#### 6.1 Make the process clear — 过程清楚
+
+Reconstruct the complete event timeline and the process that created and detected the
+problem. Compare required versus actual activities, records, decisions, controls, and
+handoffs. Identify management weaknesses or gaps.
+
+#### 6.2 Make responsibility explicit — 责任明确
+
+Assign organizational and individual responsibility from documented duties, authority,
+actions, omissions, and evidence. Distinguish direct and indirect, primary and secondary,
+leadership and execution responsibility. Do not use responsibility analysis as a substitute
+for systemic root-cause analysis.
+
+#### 6.3 Implement management measures — 措施落实
+
+Address every management weakness with specific, checkable actions. Define the responsible
+department and person, completion date, resources, implementation evidence, and effectiveness
+check. Plan and fund medium- and long-term actions explicitly.
+
+#### 6.4 Treat the problem seriously — 严肃处理
+
+Use the event to educate personnel and improve management. Apply training, communication,
+coaching, or other organizational learning as appropriate. Apply administrative or economic
+penalties only under applicable rules for confirmed repeated problems, human-responsibility
+problems, falsification, or concealment. Recognize proactive discovery and effective
+prevention where organizational policy allows.
+
+#### 6.5 Perfect the rules — 完善规章
+
+Convert management actions into controlled management-system documents, standards,
+procedures, work instructions, or governance mechanisms. Define revision content, owner,
+approval, effective date, deployment, training, and compliance verification.
+
+**Management gate:** The process, responsibility, actions, treatment, and rules are each
+supported by evidence and address the identified management causes.
+
+### 7. Report, review, and close
+
+Use the [zeroing report template](assets/zeroing-report-template.md). For formal work, include
+the report sections and evidence described in Annex A of GB/T 29076—2021.
+
+Before closure, an authorized review must verify:
+
+- Route selection and scope were correct;
+- Localization and mechanism are evidence-backed;
+- Reproduction or alternative verification is adequate;
+- Every technical and management cause has an implemented action;
+- Effectiveness and adverse effects were evaluated;
+- Horizontal deployment and document changes are complete;
+- Reports, evidence identifiers, signatures, approvals, residual issues, and recommendations
+  are complete.
+
+Close and disband the team only after all actions are implemented and verified, lessons are
+deployed, and affected parties are told that zeroing is complete.
+
+If complete zeroing is not feasible for a flight test or in-orbit issue, document the reason,
+analyze all plausible root causes, implement comprehensive controls against them, identify
+residual risk, and obtain the required approval. Never label an unresolved hypothesis as a
+confirmed cause.
+
+## Supporting Methods and Related Skills
+
+Read [engineering methods](references/engineering-methods.md) when choosing troubleshooting,
+reproduction, measure-verification, controlled-experimentation, or workflow-control methods.
+These methods are advisory and cannot weaken a standard gate.
+
+- Use [NCR writing](../../documentation/ncr-writing/) to document a detected nonconformance
+  when the organization's quality system requires an NCR before zeroing.
+- Use [Is/Is-Not](../is-is-not-scoping/) to define the observed boundary.
+- Use [Fishbone](../fishbone-analysis/) to generate candidate causes.
+- Use separate [5-Why](../5why-root-cause/) chains for distinct causal paths.
+- Use [PFMEA](../../risk-analysis/pfmea-process/) or
+  [DFMEA](../../risk-analysis/dfmea-design/) to evaluate action risk and update prevention
+  controls, and update the [Control Plan](../../planning/control-plan/) when process controls
+  change.
+- Use [CAR](../../documentation/car-corrective-action/) when the organization requires a
+  separate corrective-action record for implementation and effectiveness follow-up.
+- Use [8D](../8d-problem-solving/) when a customer or sector requires the 8D format; do not
+  claim that an 8D automatically satisfies GB/T 29076—2021 without checking every zeroing gate.
+
+Framework handoff:
+
+`Detection / NCR → zeroing route decision → technical and/or management zeroing → corrective
+action → FMEA / Control Plan / controlled-document updates → evidence review → closure`
+
+## Validation Criteria
+
+Reject closure if any answer is “no”:
+
+1. Is the exact failure location proven to the lowest practicable unit?
+2. Does the mechanism explain the observations and all confirmed root causes?
+3. Was the mechanism reproduced or otherwise verified with justified evidence?
+4. Does each action map to a confirmed cause and have implementation evidence?
+5. Was action effectiveness verified over a relevant range and checked for adverse effects?
+6. Was the exposed population searched across product, process, and organization?
+7. Where management zeroing applies, are process, responsibility, actions, treatment, and
+   rules complete?
+8. Are evidence, controlled-document revisions, reviews, approvals, residual risks, and
+   stakeholder communications traceable?
+
+## Common Mistakes
+
+- Treating repair, rework, sorting, inspection, or emergency containment as root-cause action;
+- Confusing failure location with root cause or a plausible cause with a proven mechanism;
+- Repeating a test without new instrumentation, controlled variables, or a stated hypothesis;
+- Choosing only one convenient root cause when evidence supports multiple causes;
+- Using “operator error” or “supplier problem” as the end of analysis;
+- Punishing people by default instead of correcting the management system;
+- Declaring “no similar issue found” without defining the searched population and method;
+- Closing tasks in a workflow system and assuming the quality problem is therefore zeroed;
+- Changing “完善规章” into the weaker phrase “improve the mechanism” without controlled documents;
+- Adding a sixth normative technical-zeroing requirement; knowledge extraction belongs within
+  horizontal deployment and document institutionalization.
+
+## Output Content
+
+Produce, as applicable:
+
+1. Problem and impact statement;
+2. Emergency response and affected-population record;
+3. Team, plan, zeroing-route decision, and milestones;
+4. Technical zeroing report with five evidence gates;
+5. Management zeroing report with five evidence gates;
+6. Cause-to-action-to-evidence traceability matrix;
+7. Horizontal-deployment register;
+8. Residual-risk and unresolved-item register;
+9. Review checklist, approval decision, and closure statement.
+
+## Output Format
+
+At the start of each use, ask the user:
+
+> "How would you like to receive the output?
+> **A** — Structured Markdown (formatted tables and sections, ready to copy)
+> **B** — Plain tables (simplified structure for Excel or Word)
+> **C** — Narrative report (flowing text for a formal document or email)
+>
+> Default: A."
+
+Adapt all output sections to the chosen format. If the platform or session context already defines a format preference, skip this question.
+
+## Reference Files
+
+- [GB/T 29076—2021 method guide](references/gbt-29076-2021-method-guide.md)
+- [Engineering methods and research notes](references/engineering-methods.md)
+- [Technical and management zeroing report template](assets/zeroing-report-template.md)
+
+## Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-07-04 | @Crow12138 | Initial draft based on GB/T 29076—2021 |

--- a/platforms/claude-ai/knowledge/spc-control-charts.md
+++ b/platforms/claude-ai/knowledge/spc-control-charts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: spc-control-charts
 description: >-
   Statistical Process Control (SPC) — select the correct control chart, interpret out-of-control

--- a/platforms/claude-ai/knowledge/supplier-scar.md
+++ b/platforms/claude-ai/knowledge/supplier-scar.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: supplier-scar
 description: >-
   Supplier Corrective Action Request (SCAR) — escalate a supplier non-conformance to a formal

--- a/platforms/claude-ai/knowledge/vda-6-3-audit.md
+++ b/platforms/claude-ai/knowledge/vda-6-3-audit.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: vda-6-3-audit
 description: >-
   VDA 6.3 Process Audit — conduct or prepare for a process audit using the VDA 6.3 methodology,

--- a/scripts/sync_platform_knowledge.py
+++ b/scripts/sync_platform_knowledge.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Generate the platform knowledge bundles from the canonical skills/ tree.
+
+`skills/**/SKILL.md` is the source of truth. The ChatGPT GPT and the Claude.ai
+Project load flattened copies from `platforms/*/knowledge/`. Hand-copying those
+is what let them drift to a pre-review v1.0 snapshot while the canonical files
+moved to v1.1.
+
+Usage:
+    python scripts/sync_platform_knowledge.py --check    # report drift, exit 1 if any
+    python scripts/sync_platform_knowledge.py --write    # regenerate the bundles
+
+Run --check in CI so a SKILL.md change that skips the bundles fails the build.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SKILLS = REPO / "skills"
+TARGETS = [
+    REPO / "platforms" / "chatgpt" / "knowledge",
+    REPO / "platforms" / "claude-ai" / "knowledge",
+]
+
+# Reference and asset files carried into the bundles alongside the SKILL.md
+# files. The platforms have no directory structure, so these are the ones judged
+# worth the flattening. Add to this list deliberately — every entry is extra
+# context the platform has to load on every request.
+EXTRA_FILES = [
+    "problem-solving/8d-problem-solving/assets/8d-template.md",
+    "problem-solving/8d-problem-solving/references/d0-d8-guide.md",
+    "risk-analysis/pfmea-process/assets/ap-table.md",
+    "risk-analysis/action-priority-ap/references/oem-requirements.md",
+    "documentation/8d-report-writing/references/oem-formats.md",
+]
+
+
+def build_manifest() -> dict[str, Path]:
+    """Map destination filename -> canonical source path."""
+    manifest: dict[str, Path] = {}
+
+    for skill_md in sorted(SKILLS.rglob("SKILL.md")):
+        name = skill_md.parent.name
+        if name in manifest:
+            raise SystemExit(
+                f"duplicate skill directory name {name!r} — bundle names would collide:\n"
+                f"  {manifest[name].relative_to(REPO)}\n  {skill_md.relative_to(REPO)}"
+            )
+        manifest[f"{name}.md"] = skill_md
+
+    for rel in EXTRA_FILES:
+        src = SKILLS / rel
+        if not src.exists():
+            raise SystemExit(f"EXTRA_FILES entry does not exist: skills/{rel}")
+        dest = src.name
+        if dest in manifest:
+            raise SystemExit(f"EXTRA_FILES entry {rel!r} collides with a skill name: {dest}")
+        manifest[dest] = src
+
+    return manifest
+
+
+def check(manifest: dict[str, Path]) -> int:
+    problems = 0
+    for target in TARGETS:
+        rel_target = target.relative_to(REPO)
+        expected = set(manifest)
+        actual = {p.name for p in target.glob("*.md")} if target.exists() else set()
+
+        for filename, src in sorted(manifest.items()):
+            dest = target / filename
+            if not dest.exists():
+                print(f"MISSING  {rel_target}/{filename}  <- skills/{src.relative_to(SKILLS)}")
+                problems += 1
+            elif dest.read_bytes() != src.read_bytes():
+                print(f"DRIFTED  {rel_target}/{filename}  <- skills/{src.relative_to(SKILLS)}")
+                problems += 1
+
+        for orphan in sorted(actual - expected):
+            print(f"ORPHAN   {rel_target}/{orphan}  (no canonical source — remove it or add to EXTRA_FILES)")
+            problems += 1
+
+    return problems
+
+
+def write(manifest: dict[str, Path]) -> int:
+    written = 0
+    for target in TARGETS:
+        target.mkdir(parents=True, exist_ok=True)
+        for filename, src in sorted(manifest.items()):
+            dest = target / filename
+            data = src.read_bytes()
+            if not dest.exists() or dest.read_bytes() != data:
+                dest.write_bytes(data)
+                print(f"wrote {dest.relative_to(REPO)}")
+                written += 1
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--check", action="store_true", help="report drift and exit 1 if any")
+    group.add_argument("--write", action="store_true", help="regenerate the bundles from skills/")
+    args = parser.parse_args()
+
+    manifest = build_manifest()
+
+    if args.check:
+        problems = check(manifest)
+        if problems:
+            print(
+                f"\n{problems} problem(s). The platform bundles are out of sync with skills/.\n"
+                "Run: python scripts/sync_platform_knowledge.py --write"
+            )
+            return 1
+        print(f"platform bundles in sync — {len(manifest)} files x {len(TARGETS)} platforms")
+        return 0
+
+    written = write(manifest)
+    print(f"\n{written} file(s) updated across {len(TARGETS)} platforms.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two related problems, both of which are the same failure: files derived from `skills/` were not updated when `skills/` changed.

## 1. A skill merged three weeks ago was never registered

`quality-problem-zeroing` landed on 2026-07-07 via #6. Nothing that counts skills was updated, so the repository has been advertising 22 skills against 23 on disk ever since — badge, README header, coverage table, skill index, roadmap, `STATUS.md` and the landing page. All now read 23.

Flagged 🟢 in `STATUS.md`: the skill has an `## Output Format` section and two files under `references/`.

While counting, the `STATUS.md` metric row turned out not to be reproducible. "Reference files created: 23" matched neither `references/*.md` (22 at the time) nor references plus assets (25). It is now two rows that can be checked by counting.

## 2. The platform bundles were serving pre-review content

The ChatGPT GPT and the Claude.ai Project load flattened copies of the skills from `platforms/*/knowledge/`. Measured against the canonical files: **58 drifted, 2 missing, out of 36 files across 2 platforms.**

They are not merely behind. They are **v1.0 snapshots taken before the v1.1 review round** — `fishbone-analysis.md` in both bundles reads `version: "1.0"` with no `reviewed_by` field. For roughly seven weeks both platforms have been serving content from before the review that corrected it.

### The cause is the process

`docs/maintenance-checklist.md` §5 told you to `Copy-Item` each file individually, 30+ times per release. That step gets skipped. It was.

Replaced with `scripts/sync_platform_knowledge.py`:

- `--check` reports drift and exits non-zero
- `--write` regenerates both bundles from `skills/`
- Quality Check runs `--check` on every push and PR, so a SKILL.md change that skips the bundles fails the build

Design notes: the 5 reference and asset files carried in the bundles are listed in `EXTRA_FILES` rather than inferred, because every entry is extra context the platform loads on every request — that should be a deliberate choice. Files in `knowledge/` with no canonical source are reported as orphans, not deleted. Duplicate skill directory names fail fast, since the bundles are flat and the names would collide silently.

## Validation

```
$ python scripts/validate_skills.py
✓ All checks passed (31 SKILL.md files, 59 .md files checked)

$ python scripts/sync_platform_knowledge.py --check
platform bundles in sync — 36 files x 2 platforms
```

All six workflow files were parsed. Five are valid; `welcome.yml` fails with `while scanning an alias` — that is the pre-existing bug fixed in #10, not introduced here.

**The new CI step has not yet been exercised by Actions.** Quality Check triggers only on push to `master` and pull requests against `master`, so pushing the branch did not run it. This PR is what proves it.

## Merge order

Best merged **after #9**. That PR rewrites 5 `SKILL.md` files, and it has hunks in the same `README.md` region as this one. Landing #9 first means rebasing this once, rather than resolving the same conflict twice.

Note for #9 specifically: once this lands, that PR needs a `--write` run and the regenerated bundles staged, or Quality Check will fail on master. Flagged there in a comment.

## Not closed here

Regenerating the bundles propagates whatever `master` currently says. Since #9 is not merged, the acceptance-criteria contradiction and the IATF attribution it fixes are still present in the canonical files and therefore now in the bundles too — in their current form rather than the older pre-review form. Fully closing that needs #9 merged and a second `--write`.

#8 has no `CHANGELOG.md` entry either. Not added here — that one is yours to describe.
